### PR TITLE
feat: typo exlg, sm 단위 추가

### DIFF
--- a/styles/global/_typography.scss
+++ b/styles/global/_typography.scss
@@ -27,6 +27,11 @@
   line-height: 1.6;
 }
 
+.--body-exlg-bold {
+  @include typography.body-exlg;
+  @include typography.font-weight-bold;
+}
+
 .--body-lg-bold {
   @include typography.body-lg;
   @include typography.font-weight-bold;
@@ -59,4 +64,9 @@
 .--body-md-regular {
   @include typography.body-md;
   @include typography.font-weight-regular;
+}
+
+.--body-sm-medium {
+  @include typography.body-sm;
+  @include typography.font-weight-medium;
 }

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -2,6 +2,13 @@
   font-family: var(--paperlogy-font);
   font-size: 1.5rem;
   line-height: 1.5;
+  letter-spacing: -0.01em;
+}
+
+@mixin body-exlg {
+  font-family: var(--suit-font);
+  font-size: 1.5rem;
+  line-height: 1.6;
 }
 
 @mixin body-lg {
@@ -13,6 +20,12 @@
 @mixin body-md {
   font-family: var(--suit-font);
   font-size: 1rem;
+  line-height: 1.6;
+}
+
+@mixin body-sm {
+  font-family: var(--suit-font);
+  font-size: 0.875rem;
   line-height: 1.6;
 }
 


### PR DESCRIPTION
#3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- 타이포그래피 스타일에 새로운 CSS 클래스 추가
		- 특대 굵은 본문 텍스트 스타일 (`.--body-exlg-bold`)
		- 작은 중간 굵기 본문 텍스트 스타일 (`.--body-sm-medium`)
	- 제목 큰 텍스트의 자간 미세 조정 (-0.01em)
	- 새로운 본문 텍스트 믹스인 추가 (특대, 작은 크기)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->