### PR TITLE
fix: 탈퇴 페이지 중복 확인 제거 및 메시지 수정, 설정 페이지 탈퇴 항목 정리

### DIFF
--- a/app/(setting)/delete/page.tsx
+++ b/app/(setting)/delete/page.tsx
@@ -12,10 +12,10 @@ const DeletePage = () => {
   // TODO style gap 관련하여 dvh 처리? 고민
   const [isLoading, setIsLoading] = useState(false);
 
-
-
   const handleDelete = async () => {
-    if (!confirm('정말 탈퇴하시겠습니까?')) {return;}
+    if (!confirm('정말 탈퇴하시겠습니까?')) {
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -43,7 +43,7 @@ const DeletePage = () => {
       <FunnelHeadline
         title="김척척님 <br/>척척학사를 떠나시겠어요?"
         highlightText="김척척"
-        description="척척학사에서 수집하는 개인 정보는<br/>탈퇴 즉시 폐기됩니다."
+        description="다음 패치가 있기 전까지 재가입이 불가능합니다.<br/>척척학사에서 수집하는 개인 정보는<br/>탈퇴 즉시 폐기됩니다."
       />
       <div className={styles.imageWrapper}>
         <Image src="/images/illustrations/Leave.png" alt="leave 이미지" width={300} height={300} />

--- a/app/(setting)/setting/page.tsx
+++ b/app/(setting)/setting/page.tsx
@@ -9,16 +9,6 @@ const SettingPage = () => {
 
   const menuItems = [
     {
-      label: '프로필 설정',
-      icon: <Icon name="arrow-right" size={24} />,
-      onClick: () => console.log('프로필 설정'),
-    },
-    {
-      label: '약관 및 정책',
-      icon: <Icon name="arrow-right" size={24} />,
-      onClick: () => console.log('약관 및 정책'),
-    },
-    {
       label: '탈퇴하기',
       color: '#FF5751',
       icon: <Icon name="arrow-right" size={24} />,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - 계정 삭제 안내 문구가 업데이트되어, 삭제 후 일정 기간 동안 재가입이 불가능함을 명확히 전달합니다.
  
- **New Features**
  - 설정 페이지에서 불필요한 메뉴 항목 두 개를 제거하여 인터페이스를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->