### PR TITLE
fix: 연동 유저 퍼널 재진입 차단

### DIFF
--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -78,7 +78,24 @@ export async function updateSession(request: NextRequest) {
       url.pathname = '/portal-login';
       return NextResponse.redirect(url);
     }
+
+    if (users?.portal_connected) {
+      // 만약 사용자가 portal-login, /funnel/*, /scraping 등 특정 경로 접근 시 차단하고 싶다면:
+      if (
+        request.nextUrl.pathname === '/portal-login' ||
+        request.nextUrl.pathname.startsWith('/agreement') ||
+        request.nextUrl.pathname.startsWith('/scraping') ||
+        request.nextUrl.pathname.startsWith('/target-score') ||
+        request.nextUrl.pathname.startsWith('/complete')
+      ) {
+        const url = request.nextUrl.clone();
+        url.pathname = '/main'; // 이미 연동된 유저는 /main 같은 페이지로 보낸다
+        return NextResponse.redirect(url);
+      }
+    }
   }
+
+  
 
   if (!user && !request.nextUrl.pathname.startsWith('/') && !request.nextUrl.pathname.startsWith('/auth')) {
     // no user, potentially respond by redirecting the user to the login page

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -95,8 +95,6 @@ export async function updateSession(request: NextRequest) {
     }
   }
 
-  
-
   if (!user && !request.nextUrl.pathname.startsWith('/') && !request.nextUrl.pathname.startsWith('/auth')) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 포털과 연동된 사용자가 제한된 페이지에 접근하면, 보다 원활한 이용을 위해 자동으로 메인 페이지로 이동하도록 개선되었습니다. 이는 사용자가 부적절한 경로에 진입하는 것을 방지하고 올바른 화면으로 안내받을 수 있게 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->