### PR TITLE
[fix]: 불필요한 프리로딩 중복 코드 제거

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,29 +58,6 @@ const suit = localFont({
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ko">
-      <head>
-        <link
-          rel="preload"
-          href="/fonts/Paperlogy-subset-7Bold.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="preload"
-          href="/fonts/SUIT-subset-Regular.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-        <link
-          rel="preload"
-          href="/fonts/SUIT-subset-SemiBold.woff2"
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
-      </head>
       <body className={`${paperlogy.variable} ${suit.variable} antialiased`}>
         {children}
         <Analytics />


### PR DESCRIPTION
nextjs app 하위 font 디렉토리에 폰트 파일을 둘 경우  Next.js가 자동으로 preload <link> 삽입 함으로 불필요 로직 제거 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 레이아웃에서 폰트 파일 사전 로드(head 내 preload 링크) 요소가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->