### PR TITLE
fix: resolve Kakao login redirect to localhost on dv domain

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -37,21 +37,14 @@ export function getApiBaseUrl() {
  * Frontend URL 가져오기 (환경별 로직)
  */
 export function getFrontendUrl() {
-  const env = getEnvironment();
-  
-  // 로컬 개발 환경
-  if (env === 'development' && !process.env.VERCEL_URL) {
-    return 'http://localhost:3000';
-  }
-  
-  // Vercel URL이 있으면 사용 (preview, production)
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
-
-  // 환경변수가 설정되어 있으면 사용
+  // 클라이언트 환경변수 우선 사용
   if (process.env.NEXT_PUBLIC_BASE_URL) {
     return process.env.NEXT_PUBLIC_BASE_URL;
+  }
+
+  // 브라우저에서는 현재 origin 사용
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
   }
 
   // fallback (로컬 개발용)


### PR DESCRIPTION
## Summary
- Fixed Kakao login redirect issue on dv.cchaksa.com domain
- Removed dependency on server-side only environment variables (VERCEL_ENV, VERCEL_URL)
- Prioritized NEXT_PUBLIC_BASE_URL for client-side URL resolution

## Problem
- Kakao login on dv domain was redirecting to localhost instead of dv.cchaksa.com
- Root cause: client-side code was trying to access server-only environment variables

## Solution
- Modified getFrontendUrl() to prioritize NEXT_PUBLIC_BASE_URL
- Added fallback to window.location.origin for browser environment
- Removed server-side environment variable dependencies

## Test plan
- [ ] Test Kakao login flow on dv.cchaksa.com
- [ ] Verify redirect URL is correct (https://dv.cchaksa.com/auth/callback)
- [ ] Confirm no localhost redirects occur

🤖 Generated with [Claude Code](https://claude.ai/code)