### PR TITLE
fix: enable Corepack in autofix CI workflow to resolve Yarn version mismatch

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: '20.11.0'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Add Corepack activation step to autofix CI workflow
- Resolves Yarn version mismatch error (v1.22.22 → v4.5.0)
- Fixes `yarn install --frozen-lockfile` failure in GitHub Actions

## Test plan
- [ ] Verify autofix CI workflow runs successfully
- [ ] Confirm no more Yarn version mismatch errors
- [ ] Test with actual PR to trigger autofix workflow

🤖 Generated with [Claude Code](https://claude.ai/code)