### PR TITLE
hotfix: use dynamic API base URL instead of hardcoded dev URL

### DIFF
--- a/src/shared/api/http-client.ts
+++ b/src/shared/api/http-client.ts
@@ -10,6 +10,8 @@
  * ---------------------------------------------------------------
  */
 
+import { getApiBaseUrl } from '@/config/environment';
+
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
@@ -62,7 +64,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = "https://dev.api.cchaksa.com";
+  public baseUrl: string = getApiBaseUrl();
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();


### PR DESCRIPTION
- Import getApiBaseUrl from environment config
- Replace hardcoded "https://dev.api.cchaksa.com" with getApiBaseUrl()
- Enable proper environment-based API URL configuration
- Fix production API endpoint routing

🤖 Generated with [Claude Code](https://claude.ai/code)