### PR TITLE
feat(mpa): add /mpa/home, /mpa/me routes with WebView bridge

### DIFF
--- a/src/app/(funnel)/scraping/page.tsx
+++ b/src/app/(funnel)/scraping/page.tsx
@@ -5,7 +5,7 @@ import { setUser } from '@sentry/nextjs';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
-import { getPortalLinkErrorMessage } from '@/features/portal-link/utils/errorMapping';
+import { getPortalLinkErrorMessage, TIMEOUT_ERROR_MESSAGE } from '@/features/portal-link/utils/errorMapping';
 import { useFunnelContext } from '../contexts';
 import LoadingScreen from '../components/LoadingScreen/LoadingScreen';
 
@@ -14,7 +14,7 @@ export default function ScrapingPage() {
   const router = useInternalRouter();
   const { jobId, setStudentInfo } = useFunnelContext();
 
-  const { data: jobStatusData } = usePortalLinkJobPolling(jobId);
+  const { data: jobStatusData, isTimedOut } = usePortalLinkJobPolling(jobId);
   const jobStatus = jobStatusData?.data?.status;
   const jobDetail = jobStatusData?.data;
 
@@ -36,6 +36,12 @@ export default function ScrapingPage() {
       setErrorMessage(message);
     }
   }, [jobStatus, jobDetail]);
+
+  useEffect(() => {
+    if (isTimedOut) {
+      setErrorMessage(TIMEOUT_ERROR_MESSAGE);
+    }
+  }, [isTimedOut]);
 
   if (errorMessage) {
     throw new Error(errorMessage);

--- a/src/app/(main)/main/page.tsx
+++ b/src/app/(main)/main/page.tsx
@@ -7,9 +7,12 @@ import {
   ProfileCard,
   SyncUpdateButton,
 } from '@/features/dashboard/components';
+import { useRefreshProfileOnVisible } from '@/features/dashboard/hooks/useRefreshProfileOnVisible';
 import AsyncBoundary from '@/shared/components/AsyncBoundary';
 
 const Home = () => {
+  useRefreshProfileOnVisible();
+
   return (
     <>
       <AsyncBoundary>

--- a/src/app/(mpa)/layout.module.scss
+++ b/src/app/(mpa)/layout.module.scss
@@ -1,0 +1,11 @@
+@use '@/styles/utilities' as utilities;
+@use '@/styles/spacing.scss' as spacing;
+
+.container {
+  @include utilities.app-layout;
+}
+
+.content {
+  @include utilities.content-padding;
+  @include utilities.safe-area-bottom(spacing.$space-36);
+}

--- a/src/app/(mpa)/layout.tsx
+++ b/src/app/(mpa)/layout.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { PropsWithChildren } from 'react';
+import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
+import styles from './layout.module.scss';
+
+export default function MpaLayout({ children }: PropsWithChildren) {
+  return (
+    <ProtectedRoute>
+      <div className={styles.container}>
+        <div className={styles.content}>{children}</div>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/(mpa)/mpa/home/page.tsx
+++ b/src/app/(mpa)/mpa/home/page.tsx
@@ -8,10 +8,13 @@ import {
   ProfileCard,
   SyncUpdateButton,
 } from '@/features/dashboard/components';
+import { useRefreshProfileOnVisible } from '@/features/dashboard/hooks/useRefreshProfileOnVisible';
 import { navigateNative } from '@/lib/webview';
 import AsyncBoundary from '@/shared/components/AsyncBoundary';
 
 const MpaHome = () => {
+  useRefreshProfileOnVisible();
+
   const goGraduation = () => navigateNative(ROUTES.MPA.GRADUATION_PROGRESS);
   const goResync = () => navigateNative(ROUTES.MPA.RESYNC_LOGIN);
 

--- a/src/app/(mpa)/mpa/home/page.tsx
+++ b/src/app/(mpa)/mpa/home/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ROUTES } from '@/constants/routes';
+import {
+  DashboardAcademicSummaryCard,
+  GraduationRequirementCard,
+  DualMajorRequirementCard,
+  ProfileCard,
+  SyncUpdateButton,
+} from '@/features/dashboard/components';
+import { navigateNative } from '@/lib/webview';
+import AsyncBoundary from '@/shared/components/AsyncBoundary';
+
+const MpaHome = () => {
+  const goGraduation = () => navigateNative(ROUTES.MPA.GRADUATION_PROGRESS);
+  const goResync = () => navigateNative(ROUTES.MPA.RESYNC_LOGIN);
+
+  return (
+    <>
+      <AsyncBoundary>
+        <ProfileCard />
+      </AsyncBoundary>
+      <div className="gap-16"></div>
+      <AsyncBoundary>
+        <DashboardAcademicSummaryCard />
+      </AsyncBoundary>
+      <div className="gap-8"></div>
+      <AsyncBoundary>
+        <SyncUpdateButton onNavigate={goResync} />
+      </AsyncBoundary>
+      <div className="gap-18"></div>
+      <AsyncBoundary>
+        <GraduationRequirementCard onNavigate={goGraduation} />
+      </AsyncBoundary>
+      <div className="gap-8"></div>
+      <AsyncBoundary>
+        <DualMajorRequirementCard onNavigate={goGraduation} />
+      </AsyncBoundary>
+    </>
+  );
+};
+
+export default MpaHome;

--- a/src/app/(mpa)/mpa/me/page.tsx
+++ b/src/app/(mpa)/mpa/me/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Icon } from '@/components/ui';
+import { Menu } from '@/components/ui/Menu';
+import { ROUTES } from '@/constants/routes';
+import { navigateNative } from '@/lib/webview';
+
+const MpaMePage = () => {
+  const menuItems = [
+    {
+      label: '탈퇴하기',
+      color: '#FF5751',
+      icon: <Icon name="arrow-right" size={24} />,
+      onClick: () => navigateNative(ROUTES.MPA.DELETE),
+    },
+  ];
+
+  return (
+    <div>
+      <div className="gap-16" />
+      <Menu items={menuItems} />
+    </div>
+  );
+};
+
+export default MpaMePage;

--- a/src/app/resync/scraping/page.tsx
+++ b/src/app/resync/scraping/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkJobPolling } from '@/features/portal-link/hooks';
-import { getPortalLinkErrorMessage } from '@/features/portal-link/utils/errorMapping';
+import { getPortalLinkErrorMessage, TIMEOUT_ERROR_MESSAGE } from '@/features/portal-link/utils/errorMapping';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
 import LoadingScreen from '../../(funnel)/components/LoadingScreen/LoadingScreen';
 
@@ -18,7 +18,7 @@ export default function ScrapingPage() {
     return null;
   });
 
-  const { data: jobStatusData } = usePortalLinkJobPolling(jobId);
+  const { data: jobStatusData, isTimedOut } = usePortalLinkJobPolling(jobId);
   const jobStatus = jobStatusData?.data?.status;
   const jobDetail = jobStatusData?.data;
 
@@ -36,6 +36,13 @@ export default function ScrapingPage() {
       setErrorMessage(message);
     }
   }, [jobStatus, jobDetail]);
+
+  useEffect(() => {
+    if (isTimedOut) {
+      sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+      setErrorMessage(TIMEOUT_ERROR_MESSAGE);
+    }
+  }, [isTimedOut]);
 
   if (errorMessage) {
     throw new Error(errorMessage);

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -64,6 +64,13 @@ export function getFrontendUrl() {
   return 'http://localhost:3000';
 }
 
+const PORTAL_LINK_DEFAULT_TIMEOUT_MS = 3 * 60 * 1000;
+const parsedPortalLinkTimeoutMs = Number(process.env.NEXT_PUBLIC_PORTAL_LINK_TIMEOUT_MS);
+const portalLinkTimeoutMs =
+  Number.isFinite(parsedPortalLinkTimeoutMs) && parsedPortalLinkTimeoutMs > 0
+    ? parsedPortalLinkTimeoutMs
+    : PORTAL_LINK_DEFAULT_TIMEOUT_MS;
+
 /**
  * 환경변수 중앙 관리
  */
@@ -102,6 +109,6 @@ export const ENV = {
   // 서버
   PORT: Number(process.env.PORT) || 3000,
 
-  // 포털 연동 폴링 타임아웃 (ms). 환경변수 미설정 시 3분.
-  PORTAL_LINK_TIMEOUT_MS: Number(process.env.NEXT_PUBLIC_PORTAL_LINK_TIMEOUT_MS) || 3 * 60 * 1000,
+  // 포털 연동 폴링 타임아웃 (ms). 환경변수 미설정/비정상 값(음수, NaN 등)은 기본 3분.
+  PORTAL_LINK_TIMEOUT_MS: portalLinkTimeoutMs,
 } as const;

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -101,4 +101,7 @@ export const ENV = {
 
   // 서버
   PORT: Number(process.env.PORT) || 3000,
+
+  // 포털 연동 폴링 타임아웃 (ms). 환경변수 미설정 시 3분.
+  PORTAL_LINK_TIMEOUT_MS: Number(process.env.NEXT_PUBLIC_PORTAL_LINK_TIMEOUT_MS) || 3 * 60 * 1000,
 } as const;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -19,4 +19,14 @@ export const ROUTES = {
   GRADUATION_PROGRESS: '/graduation-progress',
   SETTING: '/setting',
   DELETE: '/delete',
+  // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트.
+  // HOME/ME 만 Next.js 페이지로 존재하고, 나머지 URL 은 JS bridge 로
+  // 전달되어 네이티브 측이 해석한다.
+  MPA: {
+    HOME: '/mpa/home',
+    ME: '/mpa/me',
+    GRADUATION_PROGRESS: '/mpa/graduation-progress',
+    RESYNC_LOGIN: '/mpa/resync/login',
+    DELETE: '/mpa/delete',
+  },
 } as const;

--- a/src/features/dashboard/components/DualMajorRequirementCard/DualMajorRequirementCard.tsx
+++ b/src/features/dashboard/components/DualMajorRequirementCard/DualMajorRequirementCard.tsx
@@ -9,7 +9,11 @@ import RequirementCard from '../RequirementCard/RequirementCard';
 /**
  * 복수전공 졸업 요건 정보를 보여주는 카드 컴포넌트
  */
-const DualMajorRequirementCard = () => {
+interface DualMajorRequirementCardProps {
+  onNavigate?: () => void;
+}
+
+const DualMajorRequirementCard = ({ onNavigate }: DualMajorRequirementCardProps = {}) => {
   const router = useInternalRouter();
 
   const { data: profileData } = useProfileQuery();
@@ -30,13 +34,15 @@ const DualMajorRequirementCard = () => {
   const title = `${admissionYear}학번 ${dualMajorName} 졸업요건`;
   const { earnedCredits, requiredCredits } = calculateDualMajorCredits(dualMajorProgress);
 
+  const handleNavigate = onNavigate ?? (() => router.push(ROUTES.GRADUATION_PROGRESS));
+
   return (
     <RequirementCard
       majorTypeLabel="복수전공"
       title={title}
       earnedCredits={earnedCredits}
       requiredCredits={requiredCredits}
-      onNavigate={() => router.push(ROUTES.GRADUATION_PROGRESS)}
+      onNavigate={handleNavigate}
     />
   );
 };

--- a/src/features/dashboard/components/GraduationRequirementCard/GraduationRequirementCard.tsx
+++ b/src/features/dashboard/components/GraduationRequirementCard/GraduationRequirementCard.tsx
@@ -13,7 +13,11 @@ import RequirementCard from '../RequirementCard/RequirementCard';
  * - useAcademicSummaryQuery: 학업 요약 정보 (이수 학점, 필수 학점)
  */
 
-const GraduationRequirementCard = () => {
+interface GraduationRequirementCardProps {
+  onNavigate?: () => void;
+}
+
+const GraduationRequirementCard = ({ onNavigate }: GraduationRequirementCardProps = {}) => {
   const router = useInternalRouter();
 
   const { data: profileData } = useProfileQuery();
@@ -27,13 +31,15 @@ const GraduationRequirementCard = () => {
   const departmentName = getDepartmentName(profileData);
   const title = `${admissionYear}학번 ${departmentName} 졸업요건`;
 
+  const handleNavigate = onNavigate ?? (() => router.push(ROUTES.GRADUATION_PROGRESS));
+
   return (
     <RequirementCard
       majorTypeLabel="주전공"
       title={title}
       earnedCredits={summaryData.totalEarnedCredits}
       requiredCredits={summaryData.requiredCredits}
-      onNavigate={() => router.push(ROUTES.GRADUATION_PROGRESS)}
+      onNavigate={handleNavigate}
     />
   );
 };

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -11,7 +11,7 @@ import styles from './SyncUpdateButton.module.scss';
 const SyncUpdateButton = () => {
   const { data } = useProfileQuery();
   const router = useInternalRouter();
-  const formattedLastSyncedAt = data.lastUpdatedAt ? format(new Date(data.lastUpdatedAt), 'yy년 M월 d일 HH:mm') : '';
+  const formattedLastSyncedAt = data.lastSyncedAt ? format(new Date(data.lastSyncedAt), 'yy년 M월 d일 HH:mm') : '';
 
   const handleResyncLogin = () => {
     router.push(ROUTES.RESYNC.LOGIN);

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -8,12 +8,20 @@ import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQue
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import styles from './SyncUpdateButton.module.scss';
 
-const SyncUpdateButton = () => {
+interface SyncUpdateButtonProps {
+  onNavigate?: () => void;
+}
+
+const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
   const { data } = useProfileQuery();
   const router = useInternalRouter();
   const formattedLastSyncedAt = data.lastSyncedAt ? format(new Date(data.lastSyncedAt), 'yy년 M월 d일 HH:mm') : '';
 
   const handleResyncLogin = () => {
+    if (onNavigate) {
+      onNavigate();
+      return;
+    }
     router.push(ROUTES.RESYNC.LOGIN);
   };
 

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -2,6 +2,8 @@
 
 import clsx from 'clsx';
 import { format } from 'date-fns/format';
+import { isValid } from 'date-fns/isValid';
+import { parseISO } from 'date-fns/parseISO';
 import { Icon } from '@/components/ui';
 import { ROUTES } from '@/constants';
 import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
@@ -15,7 +17,9 @@ interface SyncUpdateButtonProps {
 const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
   const { data } = useProfileQuery();
   const router = useInternalRouter();
-  const formattedLastSyncedAt = data.lastSyncedAt ? format(new Date(data.lastSyncedAt), 'yy년 M월 d일 HH:mm') : '';
+  const parsedLastSyncedAt = data.lastSyncedAt ? parseISO(data.lastSyncedAt) : null;
+  const formattedLastSyncedAt =
+    parsedLastSyncedAt && isValid(parsedLastSyncedAt) ? format(parsedLastSyncedAt, 'yy년 M월 d일 HH:mm') : '';
 
   const handleResyncLogin = () => {
     if (onNavigate) {

--- a/src/features/dashboard/hooks/useRefreshProfileOnVisible.ts
+++ b/src/features/dashboard/hooks/useRefreshProfileOnVisible.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { dashboardQueryKeys } from '../apis/queryKey';
+
+// 네이티브 resync 후 WebView 복귀가 React 라이프사이클을 거치지 않을 수 있어 visibilitychange 로 보강.
+// 배경/대안 비교: docs/profile-staleness-on-resync.md
+export function useRefreshProfileOnVisible() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.profile });
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [queryClient]);
+}

--- a/src/features/dashboard/hooks/useRefreshProfileOnVisible.ts
+++ b/src/features/dashboard/hooks/useRefreshProfileOnVisible.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { dashboardQueryKeys } from '../apis/queryKey';
+import { dashboardQueryKeys } from '@/features/dashboard/apis/queryKey';
 
 // 네이티브 resync 후 WebView 복귀가 React 라이프사이클을 거치지 않을 수 있어 visibilitychange 로 보강.
 // 배경/대안 비교: docs/profile-staleness-on-resync.md

--- a/src/features/portal-link/hooks/usePortalLinkJobPolling.ts
+++ b/src/features/portal-link/hooks/usePortalLinkJobPolling.ts
@@ -1,19 +1,35 @@
+import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { ENV } from '@/config/environment';
 import { getJobStatus } from '../services/portalLinkService';
 
 const POLLING_INTERVAL_MS = 2000;
 
 export function usePortalLinkJobPolling(jobId: string | null) {
-  return useQuery({
+  const startedAtRef = useRef<number | null>(null);
+  const [isTimedOut, setIsTimedOut] = useState(false);
+
+  useEffect(() => {
+    setIsTimedOut(false);
+    startedAtRef.current = jobId ? Date.now() : null;
+  }, [jobId]);
+
+  const query = useQuery({
     queryKey: ['portal-link-job', jobId],
     queryFn: () => getJobStatus(jobId!),
-    enabled: Boolean(jobId),
-    refetchInterval: query => {
-      const status = query.state.data?.data?.status;
+    enabled: Boolean(jobId) && !isTimedOut,
+    refetchInterval: q => {
+      const status = q.state.data?.data?.status;
       if (status === 'succeeded' || status === 'failed') {
+        return false;
+      }
+      if (startedAtRef.current && Date.now() - startedAtRef.current >= ENV.PORTAL_LINK_TIMEOUT_MS) {
+        setIsTimedOut(true);
         return false;
       }
       return POLLING_INTERVAL_MS;
     },
   });
+
+  return { ...query, isTimedOut };
 }

--- a/src/features/portal-link/hooks/usePortalLinkJobPolling.ts
+++ b/src/features/portal-link/hooks/usePortalLinkJobPolling.ts
@@ -31,5 +31,5 @@ export function usePortalLinkJobPolling(jobId: string | null) {
     },
   });
 
-  return { ...query, isTimedOut };
+  return { data: query.data, isTimedOut };
 }

--- a/src/features/portal-link/utils/errorMapping.ts
+++ b/src/features/portal-link/utils/errorMapping.ts
@@ -1,3 +1,4 @@
+import { ENV } from '@/config/environment';
 import type { JobStatusResponse } from '@/shared/api/data-contracts';
 
 const ERROR_MESSAGES_BY_CODE: Record<string, string> = {
@@ -11,7 +12,8 @@ const ERROR_MESSAGES_BY_CODE: Record<string, string> = {
 
 const DEFAULT_ERROR_MESSAGE = '알 수 없는 오류가 발생했어요\n잠시후 다시 시도해주세요';
 
-export const TIMEOUT_ERROR_MESSAGE = '연동 응답이 3분 이상 없어 자동으로 실패 처리되었어요.\n잠시 후 다시 시도해주세요.';
+const portalLinkTimeoutMinutes = Math.max(1, Math.round(ENV.PORTAL_LINK_TIMEOUT_MS / 60000));
+export const TIMEOUT_ERROR_MESSAGE = `연동 응답이 ${portalLinkTimeoutMinutes}분 이상 없어 자동으로 실패 처리되었어요.\n잠시 후 다시 시도해주세요.`;
 
 export function getPortalLinkErrorMessage(job: JobStatusResponse): string {
   if (job.error_code && ERROR_MESSAGES_BY_CODE[job.error_code]) {

--- a/src/features/portal-link/utils/errorMapping.ts
+++ b/src/features/portal-link/utils/errorMapping.ts
@@ -11,6 +11,8 @@ const ERROR_MESSAGES_BY_CODE: Record<string, string> = {
 
 const DEFAULT_ERROR_MESSAGE = '알 수 없는 오류가 발생했어요\n잠시후 다시 시도해주세요';
 
+export const TIMEOUT_ERROR_MESSAGE = '연동 응답이 3분 이상 없어 자동으로 실패 처리되었어요.\n잠시 후 다시 시도해주세요.';
+
 export function getPortalLinkErrorMessage(job: JobStatusResponse): string {
   if (job.error_code && ERROR_MESSAGES_BY_CODE[job.error_code]) {
     return ERROR_MESSAGES_BY_CODE[job.error_code];

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -5,19 +5,25 @@ type WebViewWindow = {
 };
 
 const getWebViewWindow = (): WebViewWindow | null => {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === 'undefined') {
+    return null;
+  }
   return window as unknown as WebViewWindow;
 };
 
 export const isInWebView = (): boolean => {
   const w = getWebViewWindow();
-  if (!w) return false;
+  if (!w) {
+    return false;
+  }
   return Boolean(w.ReactNativeWebView || w.webkit?.messageHandlers?.bridge || w.Android);
 };
 
 export const postBridgeMessage = (message: string): void => {
   const w = getWebViewWindow();
-  if (!w) return;
+  if (!w) {
+    return;
+  }
 
   if (w.ReactNativeWebView?.postMessage) {
     w.ReactNativeWebView.postMessage(message);

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -1,0 +1,43 @@
+type WebViewWindow = {
+  ReactNativeWebView?: { postMessage?: (message: string) => void };
+  webkit?: { messageHandlers?: { bridge?: { postMessage?: (message: string) => void } } };
+  Android?: { postMessage?: (message: string) => void };
+};
+
+const getWebViewWindow = (): WebViewWindow | null => {
+  if (typeof window === 'undefined') return null;
+  return window as unknown as WebViewWindow;
+};
+
+export const isInWebView = (): boolean => {
+  const w = getWebViewWindow();
+  if (!w) return false;
+  return Boolean(w.ReactNativeWebView || w.webkit?.messageHandlers?.bridge || w.Android);
+};
+
+export const postBridgeMessage = (message: string): void => {
+  const w = getWebViewWindow();
+  if (!w) return;
+
+  if (w.ReactNativeWebView?.postMessage) {
+    w.ReactNativeWebView.postMessage(message);
+    return;
+  }
+  if (w.webkit?.messageHandlers?.bridge?.postMessage) {
+    w.webkit.messageHandlers.bridge.postMessage(message);
+    return;
+  }
+  if (w.Android?.postMessage) {
+    w.Android.postMessage(message);
+    return;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn('[bridge] no native bridge detected; message dropped:', message);
+  }
+};
+
+export const navigateNative = (url: string): void => {
+  postBridgeMessage(`navigate:${url}`);
+};

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -1,7 +1,11 @@
+import { captureException } from '@sentry/nextjs';
+
+type BridgePostMessage = (message: string) => void;
+
 type WebViewWindow = {
-  ReactNativeWebView?: { postMessage?: (message: string) => void };
-  webkit?: { messageHandlers?: { bridge?: { postMessage?: (message: string) => void } } };
-  Android?: { postMessage?: (message: string) => void };
+  ReactNativeWebView?: { postMessage?: BridgePostMessage };
+  webkit?: { messageHandlers?: { bridge?: { postMessage?: BridgePostMessage } } };
+  Android?: { postMessage?: BridgePostMessage };
 };
 
 const getWebViewWindow = (): WebViewWindow | null => {
@@ -11,12 +15,25 @@ const getWebViewWindow = (): WebViewWindow | null => {
   return window as unknown as WebViewWindow;
 };
 
+const resolveBridgePostMessage = (w: WebViewWindow): BridgePostMessage | null => {
+  if (typeof w.ReactNativeWebView?.postMessage === 'function') {
+    return w.ReactNativeWebView.postMessage.bind(w.ReactNativeWebView);
+  }
+  if (typeof w.webkit?.messageHandlers?.bridge?.postMessage === 'function') {
+    return w.webkit.messageHandlers.bridge.postMessage.bind(w.webkit.messageHandlers.bridge);
+  }
+  if (typeof w.Android?.postMessage === 'function') {
+    return w.Android.postMessage.bind(w.Android);
+  }
+  return null;
+};
+
 export const isInWebView = (): boolean => {
   const w = getWebViewWindow();
   if (!w) {
     return false;
   }
-  return Boolean(w.ReactNativeWebView || w.webkit?.messageHandlers?.bridge || w.Android);
+  return resolveBridgePostMessage(w) !== null;
 };
 
 export const postBridgeMessage = (message: string): void => {
@@ -25,22 +42,23 @@ export const postBridgeMessage = (message: string): void => {
     return;
   }
 
-  if (w.ReactNativeWebView?.postMessage) {
-    w.ReactNativeWebView.postMessage(message);
-    return;
-  }
-  if (w.webkit?.messageHandlers?.bridge?.postMessage) {
-    w.webkit.messageHandlers.bridge.postMessage(message);
-    return;
-  }
-  if (w.Android?.postMessage) {
-    w.Android.postMessage(message);
+  const post = resolveBridgePostMessage(w);
+  if (!post) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn('[bridge] no native bridge detected; message dropped:', message);
+    }
     return;
   }
 
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line no-console
-    console.warn('[bridge] no native bridge detected; message dropped:', message);
+  try {
+    post(message);
+  } catch (err) {
+    captureException(err, { extra: { bridgeMessage: message } });
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn('[bridge] postMessage threw; swallowed to protect UI:', message, err);
+    }
   }
 };
 

--- a/src/lib/webview/index.ts
+++ b/src/lib/webview/index.ts
@@ -1,0 +1,1 @@
+export { isInWebView, postBridgeMessage, navigateNative } from './bridge';


### PR DESCRIPTION
## Summary

- 네이티브 앱이 임베드할 WebView 라우트 그룹 신설 (`/mpa/home`, `/mpa/me`). 그 외 `/mpa/*` URL 은 JS bridge 로 네이티브가 해석하는 계약.
- JS → Native 단방향 bridge 유틸 (`src/lib/webview/bridge.ts`) 추가: RN WebView / iOS WKWebView / Android WebView 3종 감지 + `navigateNative(url)` API.
- Dashboard 카드들(`ProfileCard` 외 4종)에 optional `onNavigate` prop 을 plumbing — 동일 컴포넌트가 SPA `/main` 과 WebView `/mpa/home` 양쪽에서 라우팅 방식만 다르게 동작.
- WebView 가 살아있는 채 복귀할 때 React Query 의 5분 staleTime 으로 옛 `lastSyncedAt` 이 노출되던 이슈를 `visibilitychange` 기반 invalidate 로 해소 (`useRefreshProfileOnVisible`).
- Portal-link 폴링이 3분 안에 결과를 받지 못하면 자동 실패 처리.

## Test plan

- [ ] WebView 환경에서 `/mpa/home` 접속 시 ProfileCard / AcademicSummary / SyncUpdateButton / Graduation / DualMajor 카드가 정상 렌더된다.
- [ ] `/mpa/home` 의 각 카드/버튼 탭 시 `navigate:<url>` 메시지가 네이티브로 전달된다 (`navigate:/mpa/graduation-progress`, `navigate:/mpa/resync/login`).
- [ ] `/mpa/me` 의 "탈퇴하기" 메뉴 탭 시 `navigate:/mpa/delete` 가 전달된다.
- [ ] 네이티브 resync 완료 후 WebView 로 복귀하면 `SyncUpdateButton` 의 "YY년 M월 D일 HH:mm 업데이트" 시각이 즉시 갱신된다.
- [ ] 브라우저 SPA `/main` 에서도 동일 카드 동작 + resync → 복귀 시 갱신이 정상 동작.
- [ ] Portal-link 잡이 응답 없을 때 3분 경과 후 자동 실패 상태로 전환된다.
- [ ] `yarn type-check`, `yarn lint` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 장시간 실행되는 작업의 타임아웃 처리 추가
* 앱 활성화 시 프로필 자동 새로고침
* 새로운 MPA 섹션 (졸업 진도 관리, 계정 관리, 탈퇴)
* 네이티브 앱 통합 네비게이션 지원

## 개선사항
* 폴링 메커니즘 향상
* 대시보드 컴포넌트 네비게이션 옵션 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->