### PR TITLE
feat(mpa): MPA webview integration — home/me + school-link flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ yarn-error.log*
 .wrangler/
 
 # local docs
-docs/
+docs/*
+!docs/mpa-school-link-handoff.md
 
 # typescript
 *.tsbuildinfo

--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -14,8 +14,10 @@
 ```
 앱 (ac/re 보유, cchaksa_session 없음)
   │
-  ├─ ① POST /api/session  body: { accessToken, refreshToken, isPortalLinked }
-  │  └─ BFF: sealData → Set-Cookie: cchaksa_session
+  ├─ ① POST /api/session
+  │     headers: { x-native-bridge-secret: <합의된 시크릿> }
+  │     body:    { accessToken, refreshToken, isPortalLinked }
+  │  └─ BFF: 시크릿 검증 → sealData → Set-Cookie: cchaksa_session
   │
   ├─ ② WebView open  /mpa/resync/login
   │  └─ (mpa) layout 의 ProtectedRoute → GET /api/session → 200 OK → 폼 렌더
@@ -33,10 +35,11 @@
 
 | 변경 | 파일 | 비고 |
 |---|---|---|
-| `POST /api/session` 익스체인지 추가 | `src/app/api/session/route.ts` | 토큰 진위 검증은 TODO (백엔드 의존) |
+| `POST /api/session` 익스체인지 추가 | `src/app/api/session/route.ts` | 시크릿 헤더 게이트 + 토큰 진위 검증 TODO (백엔드 의존) |
+| `NATIVE_SESSION_EXCHANGE_SECRET` 환경변수 도입 | `src/config/environment.ts` | 미설정 시 POST 엔드포인트 503 반환 (안전 디폴트) |
 | `ROUTES.MPA.RESYNC_SCRAPING` 추가 | `src/constants/routes.ts` | `/mpa/resync/scraping` |
 | `/mpa/resync/login` 페이지 신설 | `src/app/(mpa)/mpa/resync/login/page.tsx` | 기존 `/resync/login` 흐름 mpa 컨텍스트로 복제. 성공 시 `/mpa/resync/scraping` 이동 |
-| `/mpa/resync/scraping` 페이지 신설 | `src/app/(mpa)/mpa/resync/scraping/page.tsx` | succeeded 시 `postBridgeMessage('done:portal-link')` |
+| `/mpa/resync/scraping` 페이지 신설 | `src/app/(mpa)/mpa/resync/scraping/page.tsx` | succeeded 시 `isInWebView()` 분기: webview 면 `postBridgeMessage('done:portal-link')`, 아니면 `/main` fallback. 에러/타임아웃은 throw 대신 `ErrorScreen` 인라인 렌더 |
 
 `(mpa)` route group layout 은 `ProtectedRoute(requirePortalLinked=false)` 이므로, 학교 인증 전(=신규 사용자) 상태에서도 페이지 접근 가능.
 
@@ -110,6 +113,7 @@ iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 
 ```
 POST https://cchaksa.com/api/session
 Content-Type: application/json
+X-Native-Bridge-Secret: <NATIVE_SESSION_EXCHANGE_SECRET 와 동일한 값>
 
 {
   "accessToken": "<백엔드가 발급한 ac>",
@@ -118,7 +122,11 @@ Content-Type: application/json
 }
 ```
 
-응답: `200 { ok: true, isPortalLinked: boolean }` + `Set-Cookie: cchaksa_session=...`
+응답:
+- `200 { ok: true, isPortalLinked: boolean }` + `Set-Cookie: cchaksa_session=...`
+- `503 { error: "NOT_CONFIGURED" }` — 서버에 `NATIVE_SESSION_EXCHANGE_SECRET` 환경변수 미설정
+- `403 { error: "FORBIDDEN" }` — 헤더 누락/불일치
+- `400 { error: "MISSING_ACCESS_TOKEN" | "MISSING_REFRESH_TOKEN" | "INVALID_JSON" }`
 
 ### M5. 로그아웃 동기화
 
@@ -128,8 +136,9 @@ Content-Type: application/json
 
 | 항목 | 현재 상태 | 완화 책임 |
 |---|---|---|
-| 위조 토큰으로 cchaksa_session 발급 | 가능 (B1 미구현) | 백엔드(B1) |
-| `/api/session` POST 의 CSRF | SameSite=Lax 로 부분 방어. 외부 사이트 form 으로 POST 불가 | 프론트(추가 합의 시 Origin 헤더 검증) |
+| 위조 토큰으로 cchaksa_session 발급 | 시크릿 헤더 게이트로 1차 차단. 시크릿 유출 시 위조 가능 (B1 으로 최종 차단) | 프론트(완료) → 백엔드(B1) |
+| 시크릿 키 관리 | 모바일 바이너리에 박혀 디컴파일 시 노출 위험. 회전 절차 필요 | 인프라 + 모바일 |
+| `/api/session` POST 의 CSRF | SameSite=Lax + 시크릿 헤더 요구 → 사실상 차단 (브라우저는 헤더 모름) | 프론트(완료) |
 | 앱 ↔ BFF 간 토큰 전송 평문 | HTTPS 필수 | 인프라 |
 | WKAppBoundDomains 미등록 | iOS 쿠키 7일~24시간 후 정리 | 모바일(M1) |
 
@@ -141,6 +150,9 @@ Content-Type: application/json
 - [ ] 로컬에서 `POST /api/session` 호출 후 `Set-Cookie: cchaksa_session` 발급 확인 (cURL 또는 Postman)
 - [ ] `/mpa/resync/login` 직접 진입 시 ProtectedRoute 동작 (세션 없으면 `/`)
 - [ ] `/mpa/resync/scraping` succeeded 시 `console` 또는 bridge 모킹으로 `done:portal-link` 송출 확인
+
+### 인프라
+- [ ] staging/production 에 `NATIVE_SESSION_EXCHANGE_SECRET` 시크릿 등록 (`.github/workflows/deploy-cloudflare.yml` 에 추가, 모바일과 동일 값 공유)
 
 ### 백엔드 (B1 구현 후)
 - [ ] 위조 토큰으로 `POST /api/session` 호출 시 401

--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -1,0 +1,162 @@
+# MPA 학교 인증 웹링크 — 백엔드/모바일 핸드오프
+
+> 관련 문서: `bff-auth-refactor.md` (cchaksa_session 정책), `webview-mpa-request-response.md` (MPA/네이티브 브릿지 정렬)
+> 프론트 변경: 본 문서 작성 시점 기준 머지 대기
+
+## 배경
+
+척척학사 모바일 앱(Compose Multiplatform)은 신규 가입 사용자가 학교 인증 없이도 시간표 등 일부 기능을 사용할 수 있도록 설계되어 있다. 사용자가 나중에 학교 인증을 진행할 때, **앱이 학교 인증 화면을 webview 로 띄워** 기존 웹의 `portal-link` 흐름을 그대로 재활용한다.
+
+문제: 모바일 앱은 카카오 SDK 로 직접 로그인하여 백엔드의 `accessToken` / `refreshToken` 만 보유한다. 웹의 모든 인증 API 는 `cchaksa_session` (iron-session 으로 sealData 된 HttpOnly 쿠키) 을 요구하며, 이 쿠키는 `SESSION_SECRET` 을 가진 서버만 만들 수 있다. 즉 **앱이 들고 있는 토큰을 BFF 가 cchaksa_session 으로 익스체인지해주는 경로가 필요**하다.
+
+## 호출 시퀀스 (목표 상태)
+
+```
+앱 (ac/re 보유, cchaksa_session 없음)
+  │
+  ├─ ① POST /api/session  body: { accessToken, refreshToken, isPortalLinked }
+  │  └─ BFF: sealData → Set-Cookie: cchaksa_session
+  │
+  ├─ ② WebView open  /mpa/resync/login
+  │  └─ (mpa) layout 의 ProtectedRoute → GET /api/session → 200 OK → 폼 렌더
+  │
+  ├─ ③ 사용자 학번/비번 입력 → portal-link job 생성
+  │  └─ router.push(/mpa/resync/scraping)
+  │
+  ├─ ④ scraping 페이지 폴링 → succeeded
+  │  └─ postBridgeMessage('done:portal-link')
+  │
+  └─ ⑤ 네이티브: webview 닫고 dashboard 갱신
+```
+
+## 프론트(웹) 작업 — 본 PR 에 포함
+
+| 변경 | 파일 | 비고 |
+|---|---|---|
+| `POST /api/session` 익스체인지 추가 | `src/app/api/session/route.ts` | 토큰 진위 검증은 TODO (백엔드 의존) |
+| `ROUTES.MPA.RESYNC_SCRAPING` 추가 | `src/constants/routes.ts` | `/mpa/resync/scraping` |
+| `/mpa/resync/login` 페이지 신설 | `src/app/(mpa)/mpa/resync/login/page.tsx` | 기존 `/resync/login` 흐름 mpa 컨텍스트로 복제. 성공 시 `/mpa/resync/scraping` 이동 |
+| `/mpa/resync/scraping` 페이지 신설 | `src/app/(mpa)/mpa/resync/scraping/page.tsx` | succeeded 시 `postBridgeMessage('done:portal-link')` |
+
+`(mpa)` route group layout 은 `ProtectedRoute(requirePortalLinked=false)` 이므로, 학교 인증 전(=신규 사용자) 상태에서도 페이지 접근 가능.
+
+## 백엔드 팀 요청
+
+### B1. 토큰 진위 검증 엔드포인트 (필수)
+
+현재 `POST /api/session` 은 앱이 보낸 `accessToken`/`refreshToken` 을 진위 검증 없이 그대로 sealData 한다. 위조 토큰으로 임의의 cchaksa_session 발급이 가능한 상태(쿠키만 30일 유효, 백엔드 호출은 어차피 401 로 막히지만 쿠키 자체가 쓰레기로 남음).
+
+해결안 두 가지 중 택일:
+
+- **(권장) `POST /api/auth/verify`** — body 의 accessToken 이 백엔드가 발급한 유효 토큰인지 확인하고 `200 OK { isPortalLinked }` 또는 `401` 반환. 부작용 없음(토큰 회전 안 됨)
+- **(차선) `GET /api/users/me` 같은 가벼운 인증 필수 GET 엔드포인트** — BFF 가 익스체인지 직전 호출해서 200 떨어지면 진위 OK 로 간주
+
+이 엔드포인트가 추가되면 `src/app/api/session/route.ts` 의 `POST` 핸들러에서 sealData 직전 호출하도록 `TODO(backend)` 주석을 풀어 구현한다.
+
+### B2. (옵션) 짧은 TTL 의 session-init token
+
+Auth0 의 *Native to Web SSO* 가 사용하는 패턴. 앱이 ac/re 토큰 자체 대신 짧은 TTL(예: 60초) 1회용 세션 초기화 토큰을 받아서 BFF 에 넘기는 형태. 네트워크 캡처/로그 노출 시 재사용 위험을 낮춘다. **B1 으로도 1차 차단은 충분하므로 시급도는 낮음.**
+
+## 모바일(Compose Multiplatform) 팀 요청
+
+### M1. iOS WKAppBoundDomains 등록 (필수)
+
+iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 않은 도메인의 쿠키를 강등시킨다. 우리가 발급하는 `cchaksa_session` 의 30일 maxAge 가 사실상 무력화되어 webview 진입마다 재익스체인지가 필요해진다.
+
+`Info.plist`:
+```xml
+<key>WKAppBoundDomains</key>
+<array>
+  <string>cchaksa.com</string>
+  <!-- staging 도메인도 별도 등록. 최대 10 개 제한 -->
+</array>
+```
+
+`WKWebView` 설정에 `limitsNavigationsToAppBoundDomains = true` 권장. 등록은 런타임 변경 불가, 앱 재설치 필요.
+
+### M2. JS Bridge 인터페이스 합의 (필수)
+
+웹 측 핸들러(`src/lib/webview/bridge.ts`) 가 다음 세 가지를 자동 감지한다. 모바일이 어느 형태로 노출하든 한 가지만 충족하면 동작.
+
+| 플랫폼 | 노출 형태 | 비고 |
+|---|---|---|
+| RN/유사 | `window.ReactNativeWebView.postMessage(string)` | RN 표준 |
+| iOS WKWebView | `window.webkit.messageHandlers.bridge.postMessage(string)` | 핸들러 이름이 `bridge` 이어야 함 (필수) |
+| Android | `window.Android.postMessage(string)` | `addJavascriptInterface(obj, "Android")` 형태 |
+
+**합의 필요**: iOS 의 message handler 등록 이름. 현재 코드는 `bridge` 가정. 다른 이름이면 `bridge.ts` 수정 필요.
+
+### M3. 메시지 프로토콜 합의 (필수)
+
+현재 웹이 송출하는 메시지 형식 (모두 `string`):
+
+| 메시지 | 송출 위치 | 의미 |
+|---|---|---|
+| `navigate:<path>` | `src/lib/webview/bridge.ts` `navigateNative()` | 네이티브가 해당 path 로 화면 전환 (예: `navigate:/mpa/graduation-progress`) |
+| `done:portal-link` | `/mpa/resync/scraping` succeeded 시 | 학교 인증 잡 완료. 네이티브가 webview 닫고 dashboard 등 갱신 |
+
+**합의 필요**: `done:portal-link` 수신 시 네이티브 동작. 권장 동작:
+1. webview 컨테이너 dismiss/pop
+2. 직전 화면(예: 마이페이지·홈)에서 프로필/학사 정보 갱신 트리거
+
+### M4. POST /api/session 익스체인지 호출 시점
+
+이전 합의(세션 갱신을 앱이 책임지는 후자 방식)에 따라:
+
+- 학교 인증 webview 진입 직전 한 번 호출 (필수)
+- 이후 앱의 ac/re 토큰이 회전될 때마다 다시 호출 (선택, webview 가 살아있는 동안 401 방지)
+
+호출 예시:
+```
+POST https://cchaksa.com/api/session
+Content-Type: application/json
+
+{
+  "accessToken": "<백엔드가 발급한 ac>",
+  "refreshToken": "<백엔드가 발급한 re>",
+  "isPortalLinked": false
+}
+```
+
+응답: `200 { ok: true, isPortalLinked: boolean }` + `Set-Cookie: cchaksa_session=...`
+
+### M5. 로그아웃 동기화
+
+앱에서 로그아웃할 때 `DELETE /api/session` 호출 권장. 안 하면 cchaksa_session 쿠키만 30일 살아있는 상태가 됨. 다음 webview 진입 시 잘못된 세션으로 시작될 위험.
+
+## 보안 고려사항
+
+| 항목 | 현재 상태 | 완화 책임 |
+|---|---|---|
+| 위조 토큰으로 cchaksa_session 발급 | 가능 (B1 미구현) | 백엔드(B1) |
+| `/api/session` POST 의 CSRF | SameSite=Lax 로 부분 방어. 외부 사이트 form 으로 POST 불가 | 프론트(추가 합의 시 Origin 헤더 검증) |
+| 앱 ↔ BFF 간 토큰 전송 평문 | HTTPS 필수 | 인프라 |
+| WKAppBoundDomains 미등록 | iOS 쿠키 7일~24시간 후 정리 | 모바일(M1) |
+
+## 검증 체크리스트
+
+### 프론트 (본 PR)
+- [x] `yarn type-check` 통과
+- [x] `yarn lint` 통과
+- [ ] 로컬에서 `POST /api/session` 호출 후 `Set-Cookie: cchaksa_session` 발급 확인 (cURL 또는 Postman)
+- [ ] `/mpa/resync/login` 직접 진입 시 ProtectedRoute 동작 (세션 없으면 `/`)
+- [ ] `/mpa/resync/scraping` succeeded 시 `console` 또는 bridge 모킹으로 `done:portal-link` 송출 확인
+
+### 백엔드 (B1 구현 후)
+- [ ] 위조 토큰으로 `POST /api/session` 호출 시 401
+- [ ] 유효 토큰으로 호출 시 200 + 쿠키 발급
+- [ ] 만료된 ac 토큰으로 호출 시 401 (refresh 자동 시도 X — 이건 별도 endpoint)
+
+### 모바일 (M1~M5 구현 후)
+- [ ] iOS: 앱 재시작 후에도 cchaksa_session 살아있음 (WKAppBoundDomains 효과 검증)
+- [ ] iOS: WKWebView 에서 `window.webkit.messageHandlers.bridge` 존재
+- [ ] Android: WebView 에서 `window.Android.postMessage` 호출 가능
+- [ ] 학교 인증 잡 succeeded 시 webview 자동 dismiss + 프로필 갱신
+- [ ] 앱 로그아웃 시 `DELETE /api/session` 호출되어 다음 webview 가 미인증 상태로 시작
+
+## 후속 과제
+
+- (B2) session-init token 도입 (보안 강화 트랙)
+- (프론트) `POST /api/session` 에 native-only 식별 헤더 검증 추가 — M2/M3 합의 후
+- (프론트) `done:portal-link` 외 메시지 확장 시 프로토콜 명세를 별도 파일(`docs/webview-bridge-protocol.md`) 로 분리
+- (앱+웹 공동) 세션 만료 중 webview 가 살아있을 때의 처리(앞 답변의 옵션 A/B/C 중 결정) — 1차 운영 후 재논의

--- a/src/app/(mpa)/mpa/resync/login/page.tsx
+++ b/src/app/(mpa)/mpa/resync/login/page.tsx
@@ -9,8 +9,8 @@ import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
-import { FunnelHeadline, SchoolCard } from '../../../../(funnel)/components';
-import styles from '../../../../resync/login/page.module.scss';
+import { FunnelHeadline, SchoolCard } from '@/app/(funnel)/components';
+import styles from '@/app/resync/login/page.module.scss';
 
 export default function MpaResyncLogin() {
   const [username, setUsername] = useState<string>('');

--- a/src/app/(mpa)/mpa/resync/login/page.tsx
+++ b/src/app/(mpa)/mpa/resync/login/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+import { captureException } from '@sentry/nextjs';
+import { FixedButton, TextField } from '@/components/ui';
+import { ROUTES } from '@/constants/routes';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { usePortalLinkMutation } from '@/features/portal-link/hooks';
+import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
+import { generateIdempotencyKey } from '@/shared/utils/idempotency';
+import { FunnelHeadline, SchoolCard } from '../../../../(funnel)/components';
+import styles from '../../../../resync/login/page.module.scss';
+
+export default function MpaResyncLogin() {
+  const [username, setUsername] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const router = useInternalRouter();
+  const linkMutation = usePortalLinkMutation();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    try {
+      setErrorMessage('');
+
+      const idempotencyKey = generateIdempotencyKey();
+      const result = await linkMutation.mutateAsync({ username, password, idempotencyKey });
+      const jobId = result.data?.job_id;
+
+      if (jobId) {
+        sessionStorage.setItem(RESYNC_JOB_ID_KEY, jobId);
+        router.push(ROUTES.MPA.RESYNC_SCRAPING);
+      } else {
+        setErrorMessage('연동 요청에 실패했습니다. 다시 시도해주세요.');
+      }
+    } catch (err: any) {
+      captureException(err);
+      setErrorMessage(err.message ?? '알 수 없는 오류가 발생했어요\n잠시후 다시 시도해주세요');
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <FunnelHeadline
+        title="재학 중인 학교<br/>계정을 연동해주세요"
+        description="척척학사에서 수집하는 개인 정보는<br/>학교 연동 후 즉시 폐기됩니다."
+      />
+
+      <form onSubmit={handleSubmit} className={styles.formContainer}>
+        <SchoolCard schoolName="수원대학교" />
+
+        <TextField
+          placeholder="학번을 입력해주세요"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          error={Boolean(errorMessage)}
+        />
+
+        <TextField
+          type="password"
+          placeholder="비밀번호를 입력해주세요"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          error={Boolean(errorMessage)}
+        />
+
+        {errorMessage && (
+          <div className={styles.errorMessage}>
+            {errorMessage.split('\n').map((line, i) => (
+              <p key={i}>{line}</p>
+            ))}
+          </div>
+        )}
+
+        <FixedButton
+          type="submit"
+          disabled={!username || !password || linkMutation.isPending}
+          isLoading={linkMutation.isPending}
+        >
+          학업 이력 동기화하기
+        </FixedButton>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(mpa)/mpa/resync/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/resync/scraping/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePortalLinkJobPolling } from '@/features/portal-link/hooks';
+import { getPortalLinkErrorMessage, TIMEOUT_ERROR_MESSAGE } from '@/features/portal-link/utils/errorMapping';
+import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
+import { postBridgeMessage } from '@/lib/webview';
+import LoadingScreen from '../../../../(funnel)/components/LoadingScreen/LoadingScreen';
+
+// 잡 완료 시 네이티브로 보내는 신호.
+// 네이티브가 이 메시지를 받으면 webview 를 닫고 dashboard 등 후속 화면을 갱신한다.
+// 프로토콜 합의는 docs/mpa-school-link-handoff.md 참조.
+const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
+
+export default function MpaScrapingPage() {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const [jobId] = useState<string | null>(() => {
+    if (typeof window !== 'undefined') {
+      return sessionStorage.getItem(RESYNC_JOB_ID_KEY);
+    }
+    return null;
+  });
+
+  const { data: jobStatusData, isTimedOut } = usePortalLinkJobPolling(jobId);
+  const jobStatus = jobStatusData?.data?.status;
+  const jobDetail = jobStatusData?.data;
+
+  useEffect(() => {
+    if (jobStatus === 'succeeded') {
+      sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+      postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+    }
+  }, [jobStatus]);
+
+  useEffect(() => {
+    if (jobStatus === 'failed' && jobDetail) {
+      sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+      const message = getPortalLinkErrorMessage(jobDetail);
+      setErrorMessage(message);
+    }
+  }, [jobStatus, jobDetail]);
+
+  useEffect(() => {
+    if (isTimedOut) {
+      sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+      setErrorMessage(TIMEOUT_ERROR_MESSAGE);
+    }
+  }, [isTimedOut]);
+
+  if (errorMessage) {
+    throw new Error(errorMessage);
+  }
+
+  if (!jobId) {
+    throw new Error('연동 정보를 찾을 수 없습니다. 다시 로그인해주세요.');
+  }
+
+  return <LoadingScreen />;
+}

--- a/src/app/(mpa)/mpa/resync/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/resync/scraping/page.tsx
@@ -1,19 +1,26 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { FixedButton } from '@/components/ui';
+import { ROUTES } from '@/constants/routes';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkJobPolling } from '@/features/portal-link/hooks';
 import { getPortalLinkErrorMessage, TIMEOUT_ERROR_MESSAGE } from '@/features/portal-link/utils/errorMapping';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
-import { postBridgeMessage } from '@/lib/webview';
-import LoadingScreen from '../../../../(funnel)/components/LoadingScreen/LoadingScreen';
+import { isInWebView, postBridgeMessage } from '@/lib/webview';
+import ErrorScreen from '@/app/(funnel)/components/ErrorScreen/ErrorScreen';
+import LoadingScreen from '@/app/(funnel)/components/LoadingScreen/LoadingScreen';
+import errorStyles from '@/app/resync/scraping/error.module.scss';
 
-// 잡 완료 시 네이티브로 보내는 신호.
-// 네이티브가 이 메시지를 받으면 webview 를 닫고 dashboard 등 후속 화면을 갱신한다.
+// 잡 완료 시 네이티브로 보내는 신호. webview 환경 아니면 fallback 으로 main 이동.
 // 프로토콜 합의는 docs/mpa-school-link-handoff.md 참조.
 const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
 
+const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없어요\n다시 로그인해주세요';
+
 export default function MpaScrapingPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const router = useInternalRouter();
 
   const [jobId] = useState<string | null>(() => {
     if (typeof window !== 'undefined') {
@@ -27,11 +34,16 @@ export default function MpaScrapingPage() {
   const jobDetail = jobStatusData?.data;
 
   useEffect(() => {
-    if (jobStatus === 'succeeded') {
-      sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
-      postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+    if (jobStatus !== 'succeeded') {
+      return;
     }
-  }, [jobStatus]);
+    sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+    if (isInWebView()) {
+      postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+    } else {
+      router.push(ROUTES.MAIN);
+    }
+  }, [jobStatus, router]);
 
   useEffect(() => {
     if (jobStatus === 'failed' && jobDetail) {
@@ -48,12 +60,26 @@ export default function MpaScrapingPage() {
     }
   }, [isTimedOut]);
 
-  if (errorMessage) {
-    throw new Error(errorMessage);
-  }
+  const handleRetry = () => {
+    router.push(ROUTES.MPA.RESYNC_LOGIN);
+  };
 
   if (!jobId) {
-    throw new Error('연동 정보를 찾을 수 없습니다. 다시 로그인해주세요.');
+    return (
+      <div className={errorStyles.container}>
+        <ErrorScreen errorMessage={MISSING_JOB_MESSAGE} />
+        <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
+      </div>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <div className={errorStyles.container}>
+        <ErrorScreen errorMessage={errorMessage} />
+        <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
+      </div>
+    );
   }
 
   return <LoadingScreen />;

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -21,3 +21,42 @@ export async function DELETE() {
   session.destroy();
   return NextResponse.json({ ok: true });
 }
+
+interface SessionExchangeBody {
+  accessToken?: unknown;
+  refreshToken?: unknown;
+  isPortalLinked?: unknown;
+}
+
+// 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
+// docs/mpa-school-link-handoff.md 의 시퀀스 참조.
+// TODO(backend): 백엔드에 토큰 진위 검증 엔드포인트가 추가되면 여기서 호출해 위조 토큰 차단.
+// TODO(mobile-handshake): 네이티브 전용 요청 식별 방식(전용 헤더 또는 Origin) 합의 후 검증 추가.
+export async function POST(request: Request) {
+  let body: SessionExchangeBody;
+  try {
+    body = (await request.json()) as SessionExchangeBody;
+  } catch {
+    return NextResponse.json({ error: 'INVALID_JSON' }, { status: 400 });
+  }
+
+  const { accessToken, refreshToken, isPortalLinked } = body;
+
+  if (typeof accessToken !== 'string' || accessToken.length === 0) {
+    return NextResponse.json({ error: 'MISSING_ACCESS_TOKEN' }, { status: 400 });
+  }
+  if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
+    return NextResponse.json({ error: 'MISSING_REFRESH_TOKEN' }, { status: 400 });
+  }
+
+  const session = await getSession();
+  session.accessToken = accessToken;
+  session.refreshToken = refreshToken;
+  session.isPortalLinked = typeof isPortalLinked === 'boolean' ? isPortalLinked : false;
+  await session.save();
+
+  return NextResponse.json({
+    ok: true,
+    isPortalLinked: session.isPortalLinked,
+  });
+}

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
+import { ENV } from '@/config/environment';
 import { getSession } from '@/lib/auth/session';
+
+const NATIVE_BRIDGE_SECRET_HEADER = 'x-native-bridge-secret';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,9 +33,23 @@ interface SessionExchangeBody {
 
 // 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
 // docs/mpa-school-link-handoff.md 의 시퀀스 참조.
-// TODO(backend): 백엔드에 토큰 진위 검증 엔드포인트가 추가되면 여기서 호출해 위조 토큰 차단.
-// TODO(mobile-handshake): 네이티브 전용 요청 식별 방식(전용 헤더 또는 Origin) 합의 후 검증 추가.
+//
+// 보안 게이트:
+//   1. NATIVE_SESSION_EXCHANGE_SECRET 미설정 시 503 (엔드포인트 비활성).
+//   2. 요청 헤더 x-native-bridge-secret 가 환경변수와 일치해야 함 (모바일과 사전 공유).
+// 게이트는 일반 브라우저/외부 호출의 위조 우회를 막기 위한 것이며, 토큰 자체의 진위 검증은 별도.
+// TODO(backend): 백엔드에 토큰 진위 검증 엔드포인트가 추가되면 sealData 직전 호출해 위조 토큰 차단.
 export async function POST(request: Request) {
+  const expectedSecret = ENV.NATIVE_SESSION_EXCHANGE_SECRET;
+  if (!expectedSecret) {
+    return NextResponse.json({ error: 'NOT_CONFIGURED' }, { status: 503 });
+  }
+
+  const providedSecret = request.headers.get(NATIVE_BRIDGE_SECRET_HEADER);
+  if (providedSecret !== expectedSecret) {
+    return NextResponse.json({ error: 'FORBIDDEN' }, { status: 403 });
+  }
+
   let body: SessionExchangeBody;
   try {
     body = (await request.json()) as SessionExchangeBody;

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -111,4 +111,8 @@ export const ENV = {
 
   // 포털 연동 폴링 타임아웃 (ms). 환경변수 미설정/비정상 값(음수, NaN 등)은 기본 3분.
   PORTAL_LINK_TIMEOUT_MS: portalLinkTimeoutMs,
+
+  // 네이티브 → BFF 토큰 익스체인지(POST /api/session) 게이트 시크릿.
+  // 미설정 시 엔드포인트가 503 으로 비활성화. 모바일 ↔ 백엔드 간 사전 합의 후 주입.
+  NATIVE_SESSION_EXCHANGE_SECRET: process.env.NATIVE_SESSION_EXCHANGE_SECRET ?? null,
 } as const;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -20,13 +20,15 @@ export const ROUTES = {
   SETTING: '/setting',
   DELETE: '/delete',
   // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트.
-  // HOME/ME 만 Next.js 페이지로 존재하고, 나머지 URL 은 JS bridge 로
-  // 전달되어 네이티브 측이 해석한다.
+  // HOME/ME, RESYNC_LOGIN/RESYNC_SCRAPING 은 Next.js 페이지로 존재하고,
+  // 나머지 URL (GRADUATION_PROGRESS, DELETE 등) 은 JS bridge 로 전달되어
+  // 네이티브 측이 해석한다.
   MPA: {
     HOME: '/mpa/home',
     ME: '/mpa/me',
     GRADUATION_PROGRESS: '/mpa/graduation-progress',
     RESYNC_LOGIN: '/mpa/resync/login',
+    RESYNC_SCRAPING: '/mpa/resync/scraping',
     DELETE: '/mpa/delete',
   },
 } as const;


### PR DESCRIPTION
## Summary

이번 PR은 모바일 앱(Compose Multiplatform) 의 WebView 통합을 위한 누적 변경. dev 기준 9개 커밋, 핵심은:

- **WebView JS bridge 유틸리티** (`src/lib/webview/`) — RN/iOS WKWebView/Android 세 가지 자동 감지
- **/mpa route group** — `/mpa/home`, `/mpa/me` 신설, dashboard 컴포넌트에 `onNavigate` 주입
- **/mpa/resync/{login, scraping}** — 학교 인증 webview 흐름. (mpa) layout 의 `ProtectedRoute(requirePortalLinked=false)` 활용해 미연동 사용자도 진입 가능
- **POST /api/session** — 네이티브가 보유한 ac/re 토큰을 `cchaksa_session` 쿠키로 익스체인지. 토큰 진위 검증은 백엔드 엔드포인트 도입 후 추가 예정 (TODO)
- **dashboard visibilitychange** — 네이티브 resync 후 webview 복귀 시 프로필 자동 갱신
- **portal-link 3분 타임아웃** — 폴링 자동 실패 처리
- **docs/mpa-school-link-handoff.md** — 백엔드/모바일 핸드오프 문서

## Test plan

- [x] `yarn type-check` 통과
- [x] `yarn lint` 통과 (변경 파일 0 errors)
- [ ] 로컬에서 `POST /api/session` 호출 → `Set-Cookie: cchaksa_session` 발급 확인 (cURL/Postman)
- [ ] `/mpa/resync/login` 직접 진입 시 ProtectedRoute 동작 (세션 없으면 `/` 리다이렉트)
- [ ] `/mpa/resync/scraping` jobStatus succeeded 시 `postBridgeMessage('done:portal-link')` 송출 (콘솔 또는 mock bridge)
- [ ] Dashboard 방문 후 visibilitychange 이벤트로 프로필 재페치 트리거 확인
- [ ] portal-link 잡 3분 초과 시 자동 실패 메시지 노출

## Notes

- 백엔드(토큰 검증), 모바일(WKAppBoundDomains, bridge handler 이름, 메시지 프로토콜, 호출 시퀀스, 로그아웃 동기화) 측 액션 아이템은 `docs/mpa-school-link-handoff.md` 참조
- `.gitignore` 의 `docs/` 패턴을 `docs/*` + negation 으로 변경 — 핸드오프 문서가 추적되도록

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 학교 계정 재동기화: 모바일 앱에서 학교 인증 절차를 웹뷰에서 진행할 수 있으며, 학번과 비밀번호를 통한 재인증을 지원합니다.
  * 세션 교환 API: 모바일 앱의 액세스 토큰과 리프레시 토큰을 서버 세션으로 교환하는 새로운 엔드포인트를 추가합니다.

* **Documentation**
  * 모바일 학교 인증 웹링크 통합을 위한 백엔드, 프론트엔드, 모바일 간 상세한 핸드오프 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->