### PR TITLE
hotfix(ci): pin wrangler 4.81.1 to keep Node 20 compatibility

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -90,6 +90,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4.90.0'
+          wranglerVersion: '4.81.1'
           packageManager: yarn
           command: deploy --env ${{ needs.resolve-env.outputs.name }}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "swagger-typescript-api": "^13.1.1",
     "typescript": "5.6.3",
     "vitest": "^3.0.5",
-    "wrangler": "^4.59.1"
+    "wrangler": "4.81.1"
   },
   "packageManager": "yarn@4.5.0",
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,57 +2292,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/kv-asset-handler@npm:0.5.0":
-  version: 0.5.0
-  resolution: "@cloudflare/kv-asset-handler@npm:0.5.0"
-  checksum: 10c0/46863066ff1628aa76946db6ecb5088ae64ba15d7bda7e4935bd1ab1dcf080cef9cd0920205c9508721153365ef1305984e3584e7ad2dd1c9454df984f441edb
+"@cloudflare/kv-asset-handler@npm:0.4.2":
+  version: 0.4.2
+  resolution: "@cloudflare/kv-asset-handler@npm:0.4.2"
+  checksum: 10c0/c8877851ce069b04d32d50a640c9c0faaab054970204f64a4111bac3dd85f177c001a0b57d32f7e65269e3896268b8f94605f31e4fa06253a6a5779587a63d17
   languageName: node
   linkType: hard
 
-"@cloudflare/unenv-preset@npm:2.16.1":
-  version: 2.16.1
-  resolution: "@cloudflare/unenv-preset@npm:2.16.1"
+"@cloudflare/unenv-preset@npm:2.16.0":
+  version: 2.16.0
+  resolution: "@cloudflare/unenv-preset@npm:2.16.0"
   peerDependencies:
     unenv: 2.0.0-rc.24
-    workerd: ">1.20260305.0 <2.0.0-0"
+    workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
   peerDependenciesMeta:
     workerd:
       optional: true
-  checksum: 10c0/08c9bd9ef488a14fd5330eb2c0829fc221f97f12295f8263dc8e3a6816ebd1a629e7255a3619b8bb688f1f58deafe28042c4e90ea84c926438c768f235f82ad9
+  checksum: 10c0/ddb2939cd05b5a0cb17d44b98a11b5c8e24dc6fa31171e98d8f1d7ffbb9cd35fde2ad2873715dc90db63183d6768ea43256ce3e4eb8c359542a2051f2d8bd919
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-64@npm:1.20260507.1":
-  version: 1.20260507.1
-  resolution: "@cloudflare/workerd-darwin-64@npm:1.20260507.1"
+"@cloudflare/workerd-darwin-64@npm:1.20260409.1":
+  version: 1.20260409.1
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20260409.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-darwin-arm64@npm:1.20260507.1":
-  version: 1.20260507.1
-  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20260507.1"
+"@cloudflare/workerd-darwin-arm64@npm:1.20260409.1":
+  version: 1.20260409.1
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20260409.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-64@npm:1.20260507.1":
-  version: 1.20260507.1
-  resolution: "@cloudflare/workerd-linux-64@npm:1.20260507.1"
+"@cloudflare/workerd-linux-64@npm:1.20260409.1":
+  version: 1.20260409.1
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20260409.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-linux-arm64@npm:1.20260507.1":
-  version: 1.20260507.1
-  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20260507.1"
+"@cloudflare/workerd-linux-arm64@npm:1.20260409.1":
+  version: 1.20260409.1
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20260409.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@cloudflare/workerd-windows-64@npm:1.20260507.1":
-  version: 1.20260507.1
-  resolution: "@cloudflare/workerd-windows-64@npm:1.20260507.1"
+"@cloudflare/workerd-windows-64@npm:1.20260409.1":
+  version: 1.20260409.1
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20260409.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7237,7 +7237,7 @@ __metadata:
     typescript: "npm:5.6.3"
     uuid: "npm:^11.0.3"
     vitest: "npm:^3.0.5"
-    wrangler: "npm:^4.59.1"
+    wrangler: "npm:4.81.1"
     zod: "npm:^3.24.4"
   languageName: unknown
   linkType: soft
@@ -10472,19 +10472,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miniflare@npm:4.20260507.1":
-  version: 4.20260507.1
-  resolution: "miniflare@npm:4.20260507.1"
+"miniflare@npm:4.20260409.0":
+  version: 4.20260409.0
+  resolution: "miniflare@npm:4.20260409.0"
   dependencies:
     "@cspotcode/source-map-support": "npm:0.8.1"
     sharp: "npm:^0.34.5"
-    undici: "npm:7.24.8"
-    workerd: "npm:1.20260507.1"
+    undici: "npm:7.24.4"
+    workerd: "npm:1.20260409.1"
     ws: "npm:8.18.0"
     youch: "npm:4.1.0-beta.10"
   bin:
     miniflare: bootstrap.js
-  checksum: 10c0/b74b74a5ddd6b5bb2fda190029cd07fcf1bace3085f34a60af7f4408e0d31736a042008fd7059c9831e49bf3249b02b28d60683b3ce39c921c00fe76ccc59056
+  checksum: 10c0/d53db1b87c3058637dd87e7d28ef58e6b8a0309c70c832cad274af1568c3624734408b45ec8a819282080f9b9bd65521c47b1174bdb85a766896562b0d208f16
   languageName: node
   linkType: hard
 
@@ -13425,10 +13425,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.24.8":
-  version: 7.24.8
-  resolution: "undici@npm:7.24.8"
-  checksum: 10c0/5b3cb18b1c6ccff564c37390547b2f137c666ada5083af6d5b5671dc12f73530ae2872e16fab1e3948b46013fed7c81ed10bce23f7dbf21b73794244b70b7eea
+"undici@npm:7.24.4":
+  version: 7.24.4
+  resolution: "undici@npm:7.24.4"
+  checksum: 10c0/cb302e81fadb7f0b7946ab77595715c0961b46a025ccecae79ba599432d0bc8d1e3da4dfe7ff66bc74f115c1b8ff0f099bc4e9bf313db4562da23995872c6d17
   languageName: node
   linkType: hard
 
@@ -13930,15 +13930,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerd@npm:1.20260507.1":
-  version: 1.20260507.1
-  resolution: "workerd@npm:1.20260507.1"
+"workerd@npm:1.20260409.1":
+  version: 1.20260409.1
+  resolution: "workerd@npm:1.20260409.1"
   dependencies:
-    "@cloudflare/workerd-darwin-64": "npm:1.20260507.1"
-    "@cloudflare/workerd-darwin-arm64": "npm:1.20260507.1"
-    "@cloudflare/workerd-linux-64": "npm:1.20260507.1"
-    "@cloudflare/workerd-linux-arm64": "npm:1.20260507.1"
-    "@cloudflare/workerd-windows-64": "npm:1.20260507.1"
+    "@cloudflare/workerd-darwin-64": "npm:1.20260409.1"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20260409.1"
+    "@cloudflare/workerd-linux-64": "npm:1.20260409.1"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20260409.1"
+    "@cloudflare/workerd-windows-64": "npm:1.20260409.1"
   dependenciesMeta:
     "@cloudflare/workerd-darwin-64":
       optional: true
@@ -13952,25 +13952,25 @@ __metadata:
       optional: true
   bin:
     workerd: bin/workerd
-  checksum: 10c0/5b17cb73e4c4245abec64e5400d4101aaccbf50f7ae378f843ba0d56c214a891126291e35efa4ee99420f65571f16fe78b47276e0c72ab6871526d13d01bb382
+  checksum: 10c0/8fd82ddbd71a2f20ff09d125e46f1fc1999c765aa24698975c3b5b96960d593058506a82881b14e1921b7c031eec85ca559529b15354d92fe589557d3a91e8a3
   languageName: node
   linkType: hard
 
-"wrangler@npm:^4.59.1":
-  version: 4.90.0
-  resolution: "wrangler@npm:4.90.0"
+"wrangler@npm:4.81.1":
+  version: 4.81.1
+  resolution: "wrangler@npm:4.81.1"
   dependencies:
-    "@cloudflare/kv-asset-handler": "npm:0.5.0"
-    "@cloudflare/unenv-preset": "npm:2.16.1"
+    "@cloudflare/kv-asset-handler": "npm:0.4.2"
+    "@cloudflare/unenv-preset": "npm:2.16.0"
     blake3-wasm: "npm:2.1.5"
     esbuild: "npm:0.27.3"
     fsevents: "npm:~2.3.2"
-    miniflare: "npm:4.20260507.1"
+    miniflare: "npm:4.20260409.0"
     path-to-regexp: "npm:6.3.0"
     unenv: "npm:2.0.0-rc.24"
-    workerd: "npm:1.20260507.1"
+    workerd: "npm:1.20260409.1"
   peerDependencies:
-    "@cloudflare/workers-types": ^4.20260507.1
+    "@cloudflare/workers-types": ^4.20260409.1
   dependenciesMeta:
     fsevents:
       optional: true
@@ -13980,7 +13980,7 @@ __metadata:
   bin:
     wrangler: bin/wrangler.js
     wrangler2: bin/wrangler.js
-  checksum: 10c0/c8bbab061fc51cdbd500b34aeb7a3a938984085edf7c8da0f0924ef4b7454c3e05937978c8f2a6bd426506f06dd7b09869be5735915d645f5320263f854766e3
+  checksum: 10c0/c738e72b9e005d8b9c2b712231da220f1386c7401bc10efea2b73e3a35809104ebb13fb8fb548979ec26e2da3ac50e161219e4d31bd7e9c25d0b4bc5e0941716
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 증상

`main` 푸시 후 Cloudflare Workers 운영 배포 실패. dev 푸시도 PR #169 머지 시점부터 동일.

```
⛅️ wrangler 3.90.0 (update available 4.90.1)
▲ [WARNING] No environment found in configuration with name "production".
✘ [ERROR] Missing entry-point: ... or the `main` config field.
```

## 근본 원인 (두 단계 체인)

**1) Wrangler 4.86+ 가 Node 22 강제**

PR #169 에서 `wrangler ^4 → ^4.59.1` 로 하한을 올리면서 yarn install 이 4.90.0 을 잠금. wrangler 4.86 부터 Node 22+ 강제하는데, CI 는 Node 20 사용.

```
[command] yarn wrangler --version
→ "Wrangler requires at least Node.js v22.0.0. You are using v20.20.2."
```

**2) wrangler-action@v3 의 fallback 오판**

Node 버전 에러를 "wrangler 미설치" 로 해석하여 번들된 3.90.0 강제 설치:

```
⚠️ Wrangler not found or version is incompatible. Installing...
[command] yarn add wrangler@3.90.0
```

wrangler 3.90.0 은 `.jsonc` config 미지원 (지원은 3.91+). 결과적으로 `wrangler.jsonc` 의 `env.production` / `main` 필드를 못 읽어 두 에러 동시 발생.

## PR #167 머지는 왜 됐었나

5/5 시점 yarn.lock 의 wrangler 는 **4.81.1** (당시 `^4` 범위 안에서 최신). 4.81.1 은 Node 20 에서 정상 동작 → action 이 pre-installed 로 감지 → 성공.

## 변경

- `package.json`: `wrangler ^4.59.1 → 4.81.1` (정확 핀, 4.x 라인 중 Node 20 동작 가능한 마지막)
- `yarn.lock`: 4.90.0 → 4.81.1 재생성 (yarn up wrangler@4.81.1)
- `.github/workflows/deploy-cloudflare.yml`: `wranglerVersion: '4.81.1'` + `packageManager: yarn` 추가 (action 의 broken auto-detect 우회)

## 알려진 trade-off

`@opennextjs/cloudflare ^1.19.8` 이 wrangler `^4.86.0` 을 peer 로 요청 → yarn install 시 peer warning 발생 (에러 아님). 다음 cloudflare 어댑터 업그레이드 시 Node 22 와 같이 이전해야 함.

## Test plan

- [ ] 머지 전 `gh workflow run deploy-cloudflare.yml --ref hotfix/wrangler-node20-compat -f environment=staging` 으로 staging 검증
- [ ] 머지 후 `Deploy to Cloudflare Workers` job 에서 `wrangler 4.81.1` 로 실행되는지 확인
- [ ] `cchaksa` Worker 정상 배포 + 운영 도메인 응답

## Follow-up

- Node 20 → 22 마이그레이션 (workflow + 로컬 `.nvmrc` + README)
- 그 후 wrangler / @opennextjs/cloudflare 최신화 재시도

Closes #170 (이전 PR — 잘못된 첫 커밋 포함되어 폐기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * Cloudflare Workers 배포 도구가 버전 4.81.1로 업데이트되었습니다.
  * 개발용 워크러너(wrangler) 의존성이 버전 4.81.1로 업데이트되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gyumong/chukchuk-haksa/pull/171)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gyumong/chukchuk-haksa/pull/171)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->