### PR TITLE
feat(mpa): add /mpa/graduation-progress as real Next.js page

### DIFF
--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -111,8 +111,17 @@ iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 
 
 | 메시지 | 송출 위치 | 의미 |
 |---|---|---|
-| `navigate:<path>` | `src/lib/webview/bridge.ts` `navigateNative()` | 네이티브가 해당 path 로 화면 전환 (예: `navigate:/mpa/graduation-progress`) |
+| `navigate:<path>` | `src/lib/webview/bridge.ts` `navigateNative()` | 네이티브가 해당 path 로 화면 전환. path 처리 방식은 아래 path 표 참조 |
 | `done:portal-link` | `/mpa/resync/scraping` succeeded 시 | 학교 인증 잡 완료. 네이티브가 webview 닫고 dashboard 등 갱신 |
+
+**`navigate:<path>` path 처리 방식 (모바일 팀 합의 필수)**
+
+| path | 처리 방식 | 게이트 |
+|---|---|---|
+| `/mpa/home`, `/mpa/me`, `/mpa/graduation-progress`, `/mpa/resync/login`, `/mpa/resync/scraping` | **실재하는 Next.js 페이지** — webview 로 그대로 로드 (loadUrl 가능) | FE `ProtectedRoute` |
+| `/mpa/delete` | **dispatch key (Next.js 페이지 없음)** — 네이티브 자체 화면/액션으로 해석. 절대 그대로 loadUrl 금지 (404) | 네이티브 책임 |
+
+`/mpa/graduation-progress` 는 `(mpa)` 레이아웃 + `requirePortalLinked={true}` 게이트 적용. 미연동 사용자는 `/mpa/home` 으로 리다이렉트.
 
 **합의 필요**: `done:portal-link` 수신 시 네이티브 동작. 권장 동작:
 1. webview 컨테이너 dismiss/pop

--- a/src/app/(mpa)/mpa/graduation-progress/page.tsx
+++ b/src/app/(mpa)/mpa/graduation-progress/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { ROUTES } from '@/constants/routes';
+import GraduationProgressContent from '@/features/academic/components/progress/GraduationProgressContent';
+import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
+
+export default function MpaGraduationProgress() {
+  return (
+    <ProtectedRoute requirePortalLinked={true} redirectTo={ROUTES.MPA.HOME}>
+      <GraduationProgressContent />
+    </ProtectedRoute>
+  );
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -20,9 +20,10 @@ export const ROUTES = {
   SETTING: '/setting',
   DELETE: '/delete',
   // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트.
-  // HOME/ME, RESYNC_LOGIN/RESYNC_SCRAPING 은 Next.js 페이지로 존재하고,
-  // 나머지 URL (GRADUATION_PROGRESS, DELETE 등) 은 JS bridge 로 전달되어
-  // 네이티브 측이 해석한다.
+  // HOME/ME, GRADUATION_PROGRESS, RESYNC_LOGIN/RESYNC_SCRAPING 은 Next.js 페이지로 실재하며
+  // 네이티브가 webview 로 직접 로드한다.
+  // DELETE 는 Next.js 페이지가 없는 JS bridge dispatch key 로, navigateNative()
+  // 송출 시 네이티브가 자체 화면/액션으로 해석한다.
   MPA: {
     HOME: '/mpa/home',
     ME: '/mpa/me',


### PR DESCRIPTION
## Summary
- 졸업진행도 화면을 dispatch key(브릿지 액션) 대신 **실재하는 Next.js 페이지** `/mpa/graduation-progress` 로 신설. 네이티브는 `navigate:/mpa/graduation-progress` 수신 시 webview 로 그대로 loadUrl 하면 됨 (path 매핑/transformation 불필요).
- 기존 `(main)/graduation-progress` 의 `GraduationProgressContent` 컴포넌트를 그대로 재사용 → 웹/MPA 두 컨텍스트에서 동일한 UI·로직 보장.
- `/resync/*` 가 이미 동일 패턴(웹·MPA 분리, 컨텐츠 공유)으로 분리돼 있어 일관성 확보.

## 근거
- 졸업진행도는 학사 정책 변경에 자주 영향받는 영역 → 웹 배포로 즉시 반영 가능한 webview 방식이 앱 배포 사이클 비용 회피에 유리.
- `(mpa)` layout 의 기본 `ProtectedRoute` 위에 페이지 레벨 `ProtectedRoute(requirePortalLinked=true, redirectTo=ROUTES.MPA.HOME)` 로 이중 게이트. 미연동 사용자는 `/mpa/home` 으로 리다이렉트되어 webview 컨텍스트 유지.
- `(main)` 버전과 달리 `GraduationNavigationHeader` 미포함 — 네이티브가 자체 chrome(back, title) 제공.

## 변경
- `src/app/(mpa)/mpa/graduation-progress/page.tsx` 신설
- `src/constants/routes.ts` — `MPA.GRADUATION_PROGRESS` 그룹 주석 갱신. DELETE 만 dispatch key 그룹에 잔존
- `docs/mpa-school-link-handoff.md` — M3 메시지 표 아래에 `navigate:<path>` path 처리 방식 표 추가. 각 `/mpa/*` path 가 실재 페이지인지 dispatch key 인지 명시 (모바일 팀이 webView.loadUrl 직접 호출 가능 여부를 즉시 판단)

## Test plan
- [x] `yarn type-check` 통과
- [x] `yarn lint` 통과 (변경 파일)
- [x] `GraduationProgressContent` 내부 `router.push/back` 사용 없음 확인 → 재사용 안전
- [ ] 모바일 팀: `navigate:/mpa/graduation-progress` 수신 시 webview loadUrl 동작 확인
- [ ] 미연동 사용자가 직접 진입 시 `/mpa/home` 으로 리다이렉트되는지 확인
- [ ] 연동 사용자: 졸업진행도 컨텐츠가 `(main)` 버전과 동일하게 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)