### PR TITLE
fix(mpa): promote isPortalLinked via backend probe in GET /api/session

### DIFF
--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -42,7 +42,7 @@
 
 **B1 도입 전까지의 노출 면**
 - `POST /api/session` 은 임의의 ac/re 토큰을 그대로 봉인 → 위조 호출 시 쓰레기 cchaksa_session 발급 가능 (백엔드 호출은 401 로 차단되지만 쿠키 자체는 30일 유효)
-- `isPortalLinked` 는 요청 바디에서 받지 않고 항상 `false` 강제 → 위조 호출이 portal-link 통과 상태로 세션 승격하는 경로 차단. 실제 연동 상태는 재로그인(auth callback) 또는 백엔드 me/profile 응답으로만 갱신
+- `isPortalLinked` 는 POST 요청 바디에서 받지 않고 항상 `false` 강제 → 위조 호출이 portal-link 통과 상태로 세션 승격하는 경로 차단. 실제 연동 상태는 **`GET /api/session` 핸들러가 백엔드 `GET /api/student/profile` 를 probe (3s timeout) 해서 200 응답 시 세션을 `true` 로 승격**. 한 번 승격되면 이후 호출은 추가 probe 없이 즉시 응답. 재로그인(auth callback) 경로에서도 동일하게 갱신됨
 - 발급 시점 CSRF 1차 보호: HTTPS + JSON 본문 요구 + same-origin/CORS 로 외부 페이지의 자동 POST 차단. (SameSite=Lax / HttpOnly 는 *발급된* cchaksa_session 의 후속 보호이지 발급 시점 방어선이 아님 — 서버측 `Origin` 헤더 검증 추가는 후속 강화 트랙)
 
 **재도입 트리거** (필요 시 git history 에서 게이트 코드 복원)

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,13 +1,46 @@
 import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
+import { getApiBaseUrl } from '@/config/environment';
 
 export const dynamic = 'force-dynamic';
+
+const PORTAL_LINKED_PROBE_TIMEOUT_MS = 3_000;
+
+// POST /api/session 은 보안상 isPortalLinked=false 로 강제 저장한다.
+// 실제 연동 상태는 백엔드만 알기 때문에, hydrate 시점(GET)에 backend profile 을
+// 한 번 probe 해서 200 이면 세션을 true 로 승격한다. 한 번 승격되면 이후 호출은
+// 추가 백엔드 호출 없이 즉시 응답한다.
+async function probePortalLinked(accessToken: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PORTAL_LINKED_PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/api/student/profile`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 export async function GET() {
   const session = await getSession();
 
   if (!session.accessToken) {
     return NextResponse.json({ error: 'UNAUTHENTICATED' }, { status: 401 });
+  }
+
+  if (session.isPortalLinked !== true) {
+    const linked = await probePortalLinked(session.accessToken);
+    if (linked) {
+      session.isPortalLinked = true;
+      await session.save();
+    }
   }
 
   return NextResponse.json({
@@ -30,7 +63,7 @@ interface SessionExchangeBody {
 // 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
 // 시퀀스: docs/mpa-school-link-handoff.md
 // isPortalLinked 는 요청 바디에서 받지 않고 false 로 강제. 클라이언트 임의 값으로 세션 승격되는 경로 차단.
-// 실제 연동 상태는 재로그인(auth callback) 또는 백엔드 me/profile 응답으로 갱신됨.
+// 실제 연동 상태는 GET /api/session 의 backend profile probe 또는 재로그인(auth callback) 으로 갱신됨.
 // TODO(backend): 토큰 진위 검증 엔드포인트가 추가되면 sealData 직전 호출해 위조 토큰 차단.
 export async function POST(request: Request) {
   let body: SessionExchangeBody;


### PR DESCRIPTION
## 문제

앱뷰로 진입한 사용자가 실제로 포털 연동된 상태여도 `AuthContext.isPortalLinked` 가 영구히 `false` 로 박혀있어, `/mpa/graduation-progress` 처럼 `requirePortalLinked=true` 인 페이지 진입 시 `/mpa/home` 으로 리다이렉트되는 증상.

**근본 원인** — `POST /api/session` (네이티브 토큰 익스체인지) 은 보안상 `session.isPortalLinked = false` 로 강제 저장하고 (위조 토큰으로 세션 승격되는 경로 차단), 그 후 `true` 로 승격하는 경로가 미구현. `docs/mpa-school-link-handoff.md` 의 B1 항목에는 "실제 연동 상태는 재로그인(auth callback) 또는 백엔드 me/profile 응답으로 갱신됨" 이라 적혀있었으나 실제 갱신 코드가 없었음. `setIsPortalLinked` 를 호출하는 외부 경로 부재.

웹은 OAuth callback (`src/app/auth/callback/route.ts:37`) 이 `session.isPortalLinked = true` 를 박기 때문에 동일 증상이 없다.

## 해결

`GET /api/session` 핸들러에서 `session.isPortalLinked !== true` 인 경우 backend `GET /api/student/profile` 을 **3s timeout** 으로 probe → 200 응답이면 `session.isPortalLinked = true` 로 **세션 쿠키 자체를 승격** 후 응답. 한 번 승격되면 이후 호출은 추가 backend 호출 없이 즉시 응답.

AuthContext 의 hydrate effect 가 이미 이 응답을 기다리므로, 페이지 레벨 ProtectedRoute 가 검사하는 시점에는 이미 정확한 값이 들어와 있음 → race condition 없음.

## 대안 검토 (기각 사유)

| 옵션 | 기각 사유 |
|---|---|
| 클라 측 `useProfileQuery` 후 sync effect | 네이티브가 `/mpa/graduation-progress` 를 새 webview 로 직접 로드하는 경우(M3 권장 동작), ProtectedRoute redirect 가 profile 로드보다 먼저 발사되는 race condition |
| `POST /api/session` body 의 `isPortalLinked` 신뢰 | 위조 방지 운영 결정(2026-05-05) 과 충돌 |
| `PATCH /api/session` 별도 엔드포인트 | 신규 엔드포인트 추가 + CSRF/위조 방어 재설계 필요. 같은 효과를 GET 핸들러 enrichment 로 race-free 달성 가능 |

## 실패 모드

| 시나리오 | 동작 |
|---|---|
| backend 200 | `isPortalLinked=true` 로 승격, 세션 저장 |
| backend 401/404 | 승격 안 함 (`false` 유지) → 페이지 게이트가 `/mpa/home` 리다이렉트 (fail-safe) |
| backend 5xx / 네트워크 실패 / 3s timeout | 승격 안 함, 동일 fail-safe. 가용성 우선 |

## 변경

- `src/app/api/session/route.ts`: `probePortalLinked()` 헬퍼 + GET 핸들러에 승격 로직
- `docs/mpa-school-link-handoff.md`: B1 노출 면 항목 갱신 (probe 경로 설명)

## Test plan

- [x] `yarn type-check` 통과
- [x] `yarn lint` 변경 파일 신규 이슈 없음
- [ ] 로컬에서 `POST /api/session` 으로 세션 발급 (isPortalLinked=false) → `GET /api/session` 호출 → 200 응답 + `isPortalLinked: true` 확인
- [ ] backend mock 으로 profile 401 응답 시 `GET /api/session` 이 `isPortalLinked: false` 그대로 응답하는지 확인
- [ ] backend 응답 지연 (>3s) 시 timeout 으로 `false` 응답 + 페이지 가용성 확인
- [ ] 실제 앱뷰에서 `/mpa/graduation-progress` 진입 시 `/mpa/home` 리다이렉트 안 일어나는지 확인 (이번 fix 의 핵심 검증)

## 후속

- 백엔드 토큰 진위 검증(B1) 도입 시, `POST /api/session` 의 sealData 직전에 같은 backend probe 를 옮겨 위조 토큰 차단 + 발급 시점 `isPortalLinked` 결정을 통합 가능 — 그러면 `GET` 의 enrichment 는 stale 갱신(연동 해제·재연동) 처리용으로만 남음

🤖 Generated with [Claude Code](https://claude.com/claude-code)