### PR TITLE
feat(mpa): navigateBack bridge event + webview tap-highlight fix

### DIFF
--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -114,6 +114,7 @@ iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 
 | 메시지 | 송출 위치 | 의미 |
 |---|---|---|
 | `navigate:<path>` | `src/lib/webview/bridge.ts` `navigateNative()` | 네이티브가 해당 path 로 화면 전환. path 처리 방식은 아래 path 표 참조 |
+| `navigateBack` | `src/hooks/useInternalRouter.ts` `back()` (웹뷰 & 비-funnel 경로) | 웹 화면의 `<` 뒤로가기 버튼 탭. 네이티브가 뒤로가기를 주관 |
 | `done:portal-link` | `/mpa/resync/scraping` succeeded 시 | 학교 인증 잡 완료. 네이티브가 webview 닫고 dashboard 등 갱신 |
 
 **`navigate:<path>` path 처리 방식 (모바일 팀 합의 필수)**
@@ -125,9 +126,15 @@ iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 
 
 `/mpa/graduation-progress` 는 `(mpa)` 레이아웃 + `requirePortalLinked={true}` 게이트 적용. 미연동 사용자는 `/mpa/home` 으로 리다이렉트.
 
-**합의 필요**: `done:portal-link` 수신 시 네이티브 동작. 권장 동작:
+**합의 필요 (`done:portal-link`)**: 수신 시 네이티브 동작. 권장 동작:
 1. webview 컨테이너 dismiss/pop
 2. 직전 화면(예: 마이페이지·홈)에서 프로필/학사 정보 갱신 트리거
+
+**합의 필요 (`navigateBack`)**: 웹의 `<` 뒤로가기 버튼 탭 시 송출(colon 없는 단일 토큰이라 `navigate:<path>` 파서와 비충돌). 수신 시 권장 동작:
+1. webview history depth(`WebView.canGoBack()` / `WKWebView.backForwardList`)가 1 이상이면 `webView.goBack()` 으로 웹 내부 한 단계 뒤로
+2. depth 0 이면 네이티브 내비 스택 pop 또는 webview dismiss
+3. 상세 근거: `webview-mpa-request-response.md` 권장사항 #2·#3, 시나리오 A/C
+4. `(funnel)` 경로(`/portal-login`,`/scraping`,`/agreement`,`/complete`,`/target-score`)는 웹이 송출하지 않음(퍼널 자체 흐름 보호)
 
 ### M4. POST /api/session 익스체인지 호출 시점
 

--- a/src/hooks/useInternalRouter.ts
+++ b/src/hooks/useInternalRouter.ts
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 import type { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import { useRouter } from 'next/navigation';
-import type { ROUTES } from '@/constants/routes';
+import { ROUTES } from '@/constants/routes';
+import { navigateBack } from '@/lib/webview';
+
+// (funnel) 그룹 경로. 이 경로들에서는 뒤로가기를 네이티브에 위임하지 않고 웹이 자체 처리한다.
+// 현재 funnel 은 back() 을 호출하지 않으나, 향후 추가 시 퍼널 전체가 닫히는 것을 막는 방어 가드.
+const FUNNEL_PATHS = new Set<string>(Object.values(ROUTES.FUNNEL));
 
 export const useInternalRouter = () => {
   const router = useRouter();
@@ -59,7 +64,16 @@ export const useInternalRouter = () => {
         return router.replace(url, navigateOptions);
       },
 
-      back: () => router.back(),
+      back: () => {
+        // usePathname() 은 이 훅을 쓰는 다수 컴포넌트를 매 라우팅마다 리렌더시키므로 쓰지 않고,
+        // 클릭 시점(클라이언트)에만 현재 경로를 읽어 구독 없이 판정한다.
+        const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
+        // 비-funnel 경로 & 웹뷰면 navigateBack 을 네이티브로 송출하고 위임. 그 외엔 기존대로 router.back().
+        if (!FUNNEL_PATHS.has(pathname) && navigateBack()) {
+          return;
+        }
+        router.back();
+      },
       forward: () => router.forward(),
       refresh: () => router.refresh(),
     };

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -67,3 +67,9 @@ export const postBridgeMessage = (message: string): boolean => {
 export const navigateNative = (url: string): boolean => {
   return postBridgeMessage(`navigate:${url}`);
 };
+
+// 웹 화면의 < 뒤로가기 버튼 탭을 네이티브에 위임한다. colon 없는 단일 토큰이라
+// 기존 navigate:<path> 파서와 충돌하지 않는다. 프로토콜: docs/mpa-school-link-handoff.md M3.
+export const navigateBack = (): boolean => {
+  return postBridgeMessage('navigateBack');
+};

--- a/src/lib/webview/index.ts
+++ b/src/lib/webview/index.ts
@@ -1,1 +1,1 @@
-export { isInWebView, postBridgeMessage, navigateNative } from './bridge';
+export { isInWebView, postBridgeMessage, navigateNative, navigateBack } from './bridge';

--- a/src/styles/global/_reset.scss
+++ b/src/styles/global/_reset.scss
@@ -1,5 +1,7 @@
 * {
   box-sizing: border-box;
+  /* 안드로이드/iOS 웹뷰에서 요소 탭 시 나타나는 파란 하이라이트 제거 */
+  -webkit-tap-highlight-color: transparent;
 }
 
 html,


### PR DESCRIPTION
## 변경 사항

### 1. `navigateBack` 웹뷰 브릿지 이벤트 (웹 → 네이티브)

웹 화면의 `<` 뒤로가기 버튼 탭 시, 웹뷰 환경에서는 `useInternalRouter().back()` 이 네이티브로 `navigateBack` 메시지를 송출합니다(기존 `navigateNative` 와 동일 방향/패턴). 네이티브가 뒤로가기를 주관해 네이티브 스택과 웹 히스토리를 동기화합니다.

- 웹뷰가 아니면(일반 브라우저) 기존처럼 `router.back()` 폴백 — 회귀 없음
- `(funnel)` 경로는 제외(퍼널 자체 흐름 보호용 방어 가드. 현재 funnel 은 `back()` 미사용)
- 모든 뒤로가기가 `useInternalRouter().back()` **단일 게이트**를 경유하므로 한 곳 수정으로 졸업요건/세부성적/설정/탈퇴 등 전 화면의 `<` 버튼에 적용
- 메시지는 colon 없는 `navigateBack` 단일 토큰이라 기존 `navigate:<path>` 파서와 충돌하지 않음
- 파일: `src/lib/webview/bridge.ts`, `src/lib/webview/index.ts`, `src/hooks/useInternalRouter.ts`, `docs/mpa-school-link-handoff.md` (M3)

### 2. 안드로이드 웹뷰 탭 하이라이트 제거

전역 reset 의 `*` 에 `-webkit-tap-highlight-color: transparent` 추가 — 안드로이드 웹뷰에서 버튼 탭 시 나타나는 파란 하이라이트 제거.

- 파일: `src/styles/global/_reset.scss`

## 검증

- `yarn type-check` 통과
- `yarn lint` 에러 0 (기존 경고만)
- 웹뷰 모킹(`window.ReactNativeWebView = { postMessage: m => console.log(m) }`)으로 `<` 탭 시 `navigateBack` 1회 송출 + URL 변화 없음 확인 가능. 모킹 없으면 기존대로 `router.back()`.

## 네이티브 팀 합의 필요

`navigateBack` 수신 시 동작 — webview history depth(`WebView.canGoBack()` / `WKWebView.backForwardList`)가 1 이상이면 `webView.goBack()` 으로 웹 내부 한 단계 뒤로, 0이면 네이티브 스택 pop 또는 webview dismiss. (상세: `docs/mpa-school-link-handoff.md` M3, `webview-mpa-request-response.md` 권장사항 #2·#3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
