### PR TITLE
chore: address CodeRabbit review on #176 (dev to main)

### DIFF
--- a/src/app/(mpa)/mpa/resync/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/resync/scraping/page.tsx
@@ -35,6 +35,7 @@ export default function MpaScrapingPage() {
 
   const clearJobId = useCallback(() => {
     sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+    setJobId(null);
   }, []);
 
   useEffect(() => {

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { captureException } from '@sentry/nextjs';
 import { getSession } from '@/lib/auth/session';
 import { getApiBaseUrl } from '@/config/environment';
 
@@ -21,7 +22,14 @@ async function probePortalLinked(accessToken: string): Promise<boolean> {
       cache: 'no-store',
     });
     return response.ok;
-  } catch {
+  } catch (error) {
+    // 타임아웃(AbortError)은 예상된 경로라 캡처하지 않고, 그 외 네트워크/예외만 관측한다.
+    if (!(error instanceof Error && error.name === 'AbortError')) {
+      captureException(error, {
+        tags: { scope: 'session', action: 'probePortalLinked' },
+        extra: { endpoint: '/api/student/profile', timeoutMs: PORTAL_LINKED_PROBE_TIMEOUT_MS },
+      });
+    }
     return false;
   } finally {
     clearTimeout(timeoutId);

--- a/src/app/resync/scraping/page.tsx
+++ b/src/app/resync/scraping/page.tsx
@@ -30,6 +30,7 @@ export default function ScrapingPage() {
 
   const clearJobId = useCallback(() => {
     sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+    setJobId(null);
   }, []);
 
   useEffect(() => {

--- a/src/features/portal-link/utils/credentialRetry.ts
+++ b/src/features/portal-link/utils/credentialRetry.ts
@@ -1,5 +1,6 @@
 // 자격증명 실패 후 로그인 폼으로 복귀할 때 학번/에러코드를 넘기는 핸드오프.
 // sessionStorage 기반(탭 한정). 비밀번호는 절대 저장하지 않는다.
+// 프라이버시 모드/용량 초과 시 sessionStorage 가 DOMException 을 던질 수 있어 모든 접근을 try-catch 로 감싼다.
 
 const USERNAME_KEY = 'portal-link:last-username';
 const CODE_KEY = 'portal-link:retry-code';
@@ -13,7 +14,11 @@ export function stashAttemptUsername(username: string): void {
   if (!isBrowser()) {
     return;
   }
-  sessionStorage.setItem(USERNAME_KEY, username);
+  try {
+    sessionStorage.setItem(USERNAME_KEY, username);
+  } catch {
+    // 무시. 최악의 경우 재시도 시 학번이 prefill 되지 않는 정도.
+  }
 }
 
 /** 스크래핑이 자격증명 실패를 감지했을 때 호출. 로그인 폼에서 메시지로 변환. */
@@ -21,7 +26,11 @@ export function stashRetryCode(code: string): void {
   if (!isBrowser()) {
     return;
   }
-  sessionStorage.setItem(CODE_KEY, code);
+  try {
+    sessionStorage.setItem(CODE_KEY, code);
+  } catch {
+    // 무시. 최악의 경우 에러 메시지가 표시되지 않는 정도.
+  }
 }
 
 /** 로그인 폼 mount 시 1회 호출. 값을 읽고 두 키를 모두 비운다. */
@@ -29,11 +38,15 @@ export function popRetry(): { username: string; code: string } {
   if (!isBrowser()) {
     return { username: '', code: '' };
   }
-  const username = sessionStorage.getItem(USERNAME_KEY) ?? '';
-  const code = sessionStorage.getItem(CODE_KEY) ?? '';
-  sessionStorage.removeItem(USERNAME_KEY);
-  sessionStorage.removeItem(CODE_KEY);
-  return { username, code };
+  try {
+    const username = sessionStorage.getItem(USERNAME_KEY) ?? '';
+    const code = sessionStorage.getItem(CODE_KEY) ?? '';
+    sessionStorage.removeItem(USERNAME_KEY);
+    sessionStorage.removeItem(CODE_KEY);
+    return { username, code };
+  } catch {
+    return { username: '', code: '' };
+  }
 }
 
 /** 연동 성공 시 잔여 핸드오프 값을 정리. */
@@ -41,6 +54,10 @@ export function clearRetry(): void {
   if (!isBrowser()) {
     return;
   }
-  sessionStorage.removeItem(USERNAME_KEY);
-  sessionStorage.removeItem(CODE_KEY);
+  try {
+    sessionStorage.removeItem(USERNAME_KEY);
+    sessionStorage.removeItem(CODE_KEY);
+  } catch {
+    // 정리는 best-effort. 실패해도 무시.
+  }
 }

--- a/src/features/portal-link/utils/errorMapping.ts
+++ b/src/features/portal-link/utils/errorMapping.ts
@@ -48,6 +48,6 @@ export function classifyPortalLinkFailure(job: JobStatusResponse): PortalLinkFai
   if (INELIGIBLE_CODES.has(code)) {
     return { kind: 'ineligible', code, message: getMessageByErrorCode(code), shouldCapture: false };
   }
-  // 미상 코드는 관측이 필요한 시스템 이상으로 분류
-  return { kind: 'system', code, message: DEFAULT_ERROR_MESSAGE, shouldCapture: true };
+  // 미상 코드는 관측이 필요한 시스템 이상으로 분류. 매핑된 메시지가 있으면 활용, 없으면 기본 메시지.
+  return { kind: 'system', code, message: getMessageByErrorCode(code), shouldCapture: true };
 }


### PR DESCRIPTION
PR #176 (`dev → main`)의 CodeRabbit 인라인 리뷰 5건을 반영합니다. `dev`/`main` 직접 커밋 금지 규칙에 따라, 이 fix 브랜치를 `dev`로 머지하면 #176에 자동 반영됩니다.

## 반영 내역

| 파일 | 심각도 | 조치 |
|---|---|---|
| `(mpa)/mpa/resync/scraping/page.tsx` | 🟠 Major | `clearJobId`에 `setJobId(null)` 추가 → 에러/타임아웃 화면에서 `usePortalLinkJobPolling` 폴링 중단 |
| `resync/scraping/page.tsx` | 🟠 Major | 동일 (non-mpa 버전) |
| `api/session/route.ts` | 🟠 Major | `probePortalLinked` catch에서 `captureException`로 실패 관측 |
| `portal-link/utils/credentialRetry.ts` | 🟡 Minor | 모든 `sessionStorage` 접근을 try-catch로 감싸 DOMException(프라이버시 모드/용량 초과) 대응 |
| `portal-link/utils/errorMapping.ts` | 🔵 Trivial | system 분기 메시지를 `getMessageByErrorCode(code)`로 변경 (일관성) |

## 검증

- `yarn type-check` 통과
- `yarn lint` 에러 0 (기존 경고만)

## 비고 (CodeRabbit 제안 대비 조정)

`api/session/route.ts`의 Sentry 적용은 두 가지를 제안과 다르게 처리했습니다:
1. import를 `import * as Sentry` 대신 코드베이스 컨벤션과 동일한 **named import `captureException`** (`@sentry/nextjs`) 사용
2. **타임아웃(`AbortError`)은 예상된 경로**라 캡처에서 제외 — 백엔드 지연 시 매 타임아웃마다 Sentry에 AbortError가 쌓이는 노이즈 방지. 그 외 네트워크/예외만 캡처.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
