### PR TITLE
fix(mpa): web-driven back() (re-apply navigateBack fix missed by #177)

### DIFF
--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -114,7 +114,7 @@ iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 
 | 메시지 | 송출 위치 | 의미 |
 |---|---|---|
 | `navigate:<path>` | `src/lib/webview/bridge.ts` `navigateNative()` | 네이티브가 해당 path 로 화면 전환. path 처리 방식은 아래 path 표 참조 |
-| `navigateBack` | `src/hooks/useInternalRouter.ts` `back()` (웹뷰 & 비-funnel 경로) | 웹 화면의 `<` 뒤로가기 버튼 탭. 네이티브가 뒤로가기를 주관 |
+| `navigateBack` | `src/hooks/useInternalRouter.ts` `back()` (웹뷰) | 웹 `<` 뒤로가기 버튼 탭 **알림**. 실제 뒤로가기는 웹이 `router.back()` 으로 수행하고, 네이티브는 이동하지 않고 UI 동기화(앱바 등)에만 사용 |
 | `done:portal-link` | `/mpa/resync/scraping` succeeded 시 | 학교 인증 잡 완료. 네이티브가 webview 닫고 dashboard 등 갱신 |
 
 **`navigate:<path>` path 처리 방식 (모바일 팀 합의 필수)**
@@ -130,11 +130,10 @@ iOS 14+ 의 ITP(Intelligent Tracking Prevention) 가 app-bound 로 등록되지 
 1. webview 컨테이너 dismiss/pop
 2. 직전 화면(예: 마이페이지·홈)에서 프로필/학사 정보 갱신 트리거
 
-**합의 필요 (`navigateBack`)**: 웹의 `<` 뒤로가기 버튼 탭 시 송출(colon 없는 단일 토큰이라 `navigate:<path>` 파서와 비충돌). 수신 시 권장 동작:
-1. webview history depth(`WebView.canGoBack()` / `WKWebView.backForwardList`)가 1 이상이면 `webView.goBack()` 으로 웹 내부 한 단계 뒤로
-2. depth 0 이면 네이티브 내비 스택 pop 또는 webview dismiss
-3. 상세 근거: `webview-mpa-request-response.md` 권장사항 #2·#3, 시나리오 A/C
-4. `(funnel)` 경로(`/portal-login`,`/scraping`,`/agreement`,`/complete`,`/target-score`)는 웹이 송출하지 않음(퍼널 자체 흐름 보호)
+**합의 필요 (`navigateBack`)**: 웹의 `<` 뒤로가기 버튼 탭 시 송출(colon 없는 단일 토큰이라 `navigate:<path>` 파서와 비충돌). **실제 뒤로가기는 웹이 `router.back()` 으로 직접 수행한다.** 따라서:
+1. **네이티브는 이 메시지로 `webView.goBack()` 이나 스택 pop 을 하면 안 된다** — 웹이 이미 뒤로 가므로 두 단계 back(중복 이동)이 된다.
+2. 네이티브는 이 알림을 **UI 동기화 용도로만** 사용한다(예: 앱바 타이틀/뒤로가기 표시 갱신).
+3. 웹 내부 히스토리가 없는 루트에서의 webview 종료 처리는 이 메시지로 다루지 않는다(별도 신호 필요 — 현재 미정, 후속 트랙). 참고: `webview-mpa-request-response.md`
 
 ### M4. POST /api/session 익스체인지 호출 시점
 

--- a/src/hooks/useInternalRouter.ts
+++ b/src/hooks/useInternalRouter.ts
@@ -1,12 +1,8 @@
 import { useMemo } from 'react';
 import type { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import { useRouter } from 'next/navigation';
-import { ROUTES } from '@/constants/routes';
-import { navigateBack } from '@/lib/webview';
-
-// (funnel) 그룹 경로. 이 경로들에서는 뒤로가기를 네이티브에 위임하지 않고 웹이 자체 처리한다.
-// 현재 funnel 은 back() 을 호출하지 않으나, 향후 추가 시 퍼널 전체가 닫히는 것을 막는 방어 가드.
-const FUNNEL_PATHS = new Set<string>(Object.values(ROUTES.FUNNEL));
+import type { ROUTES } from '@/constants/routes';
+import { isInWebView, navigateBack } from '@/lib/webview';
 
 export const useInternalRouter = () => {
   const router = useRouter();
@@ -65,12 +61,10 @@ export const useInternalRouter = () => {
       },
 
       back: () => {
-        // usePathname() 은 이 훅을 쓰는 다수 컴포넌트를 매 라우팅마다 리렌더시키므로 쓰지 않고,
-        // 클릭 시점(클라이언트)에만 현재 경로를 읽어 구독 없이 판정한다.
-        const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
-        // 비-funnel 경로 & 웹뷰면 navigateBack 을 네이티브로 송출하고 위임. 그 외엔 기존대로 router.back().
-        if (!FUNNEL_PATHS.has(pathname) && navigateBack()) {
-          return;
+        // 실제 뒤로가기는 항상 웹이 수행한다. 웹뷰일 때는 네이티브에도 알려(앱바 동기화 등) 주지만,
+        // 네이티브는 이 알림으로 직접 이동하지 않는다(이동 시 router.back() 과 중복). 프로토콜: M3.
+        if (isInWebView()) {
+          navigateBack();
         }
         router.back();
       },


### PR DESCRIPTION
## 배경

PR #177 이 `721b70f` 시점에 머지되면서, 그 직후 합의해 푸시한 **Model B 수정(`5ed2c4c`)이 머지에 포함되지 못했습니다.** 그 결과 현재 `dev`/`main` 에는 옛 동작(웹뷰에서 `navigateBack` 만 보내고 `router.back()` 을 스킵 → **네이티브가 핸들러를 구현하기 전엔 뒤로가기 버튼이 동작하지 않음**)이 적용돼 있습니다.

이 PR 은 누락된 `5ed2c4c` 를 `dev` 위로 cherry-pick 해 다시 반영합니다.

## 변경 (합의된 동작 = Model B)

```ts
back: () => {
  // 실제 뒤로가기는 항상 웹이 수행. 웹뷰면 네이티브에 알림(동기화용)만 추가 송출.
  if (isInWebView()) {
    navigateBack();
  }
  router.back();
},
```

- ✅ 웹이 **항상 `router.back()`** → 네이티브 구현 여부와 무관하게 뒤로가기 버튼 동작
- ✅ 웹뷰일 땐 `navigateBack` 도 송출 → 네이티브가 앱바 동기화 등에 활용
- ✅ `FUNNEL_PATHS` 가드 제거 (네이티브가 이동을 안 하므로 "퍼널 닫힘" 리스크 자체가 없어짐)

## ⚠️ 네이티브 팀 계약 (문서 M3 정정 반영)

**네이티브는 `navigateBack` 수신 시 `webView.goBack()` 이나 스택 pop 을 하면 안 됩니다.** 웹이 이미 `router.back()` 으로 뒤로 가므로 중복 이동(두 단계 back)이 됩니다. 이 메시지는 **UI 동기화 용도로만** 사용하세요.

## 검증
- `yarn type-check` 통과 / `yarn lint` 에러 0 (기존 경고만)

## 파일
- `src/hooks/useInternalRouter.ts`
- `docs/mpa-school-link-handoff.md` (M3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
