### PR TITLE
feat(mpa): add /mpa/portal-login route as distinct entry from resync

### DIFF
--- a/src/app/(mpa)/mpa/portal-login/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+// /mpa/resync/login 과 동일 폼. portal-link 별도 entry point. 프로토콜: docs/mpa-school-link-handoff.md
+import type { FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { captureException } from '@sentry/nextjs';
+import { FixedButton, TextField } from '@/components/ui';
+import { ROUTES } from '@/constants/routes';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { usePortalLinkMutation } from '@/features/portal-link/hooks';
+import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
+import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
+import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
+import { ApiError } from '@/shared/api/errors';
+import { generateIdempotencyKey } from '@/shared/utils/idempotency';
+import { FunnelHeadline, SchoolCard } from '@/app/(funnel)/components';
+import styles from '@/app/resync/login/page.module.scss';
+
+export default function MpaPortalLogin() {
+  const [username, setUsername] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const router = useInternalRouter();
+  const linkMutation = usePortalLinkMutation();
+
+  useEffect(() => {
+    const { username: retriedUsername, code } = popRetry();
+    if (retriedUsername) {
+      setUsername(retriedUsername);
+    }
+    if (code) {
+      setErrorMessage(getMessageByErrorCode(code));
+    }
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    try {
+      setErrorMessage('');
+
+      const idempotencyKey = generateIdempotencyKey();
+      stashAttemptUsername(username);
+      const result = await linkMutation.mutateAsync({ username, password, idempotencyKey });
+      const jobId = result.data?.job_id;
+
+      if (jobId) {
+        sessionStorage.setItem(PORTAL_LOGIN_JOB_ID_KEY, jobId);
+        router.push(ROUTES.MPA.PORTAL_LOGIN_SCRAPING);
+      } else {
+        setErrorMessage('연동 요청에 실패했습니다. 다시 시도해주세요.');
+      }
+    } catch (err: unknown) {
+      captureException(err);
+      const message =
+        err instanceof ApiError
+          ? err.userMessage
+          : err instanceof Error && err.message
+            ? err.message
+            : '알 수 없는 오류가 발생했어요\n잠시후 다시 시도해주세요';
+      setErrorMessage(message);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <FunnelHeadline
+        title="재학 중인 학교<br/>계정을 연동해주세요"
+        description="척척학사에서 수집하는 개인 정보는<br/>학교 연동 후 즉시 폐기됩니다."
+      />
+
+      <form onSubmit={handleSubmit} className={styles.formContainer}>
+        <SchoolCard schoolName="수원대학교" />
+
+        <TextField
+          placeholder="학번을 입력해주세요"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          error={Boolean(errorMessage)}
+        />
+
+        <TextField
+          type="password"
+          placeholder="비밀번호를 입력해주세요"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          error={Boolean(errorMessage)}
+        />
+
+        {errorMessage && (
+          <div className={styles.errorMessage}>
+            {errorMessage.split('\n').map((line, i) => (
+              <p key={i}>{line}</p>
+            ))}
+          </div>
+        )}
+
+        <FixedButton
+          type="submit"
+          disabled={!username || !password || linkMutation.isPending}
+          isLoading={linkMutation.isPending}
+        >
+          학업 이력 동기화하기
+        </FixedButton>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+// /mpa/resync/scraping 과 동일 흐름. portal-login entry point 의 후행 페이지. 프로토콜: docs/mpa-school-link-handoff.md
+import { useCallback, useEffect, useState } from 'react';
+import { FixedButton } from '@/components/ui';
+import { ROUTES } from '@/constants/routes';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
+import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
+import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
+import { isInWebView, postBridgeMessage } from '@/lib/webview';
+import ErrorScreen from '@/app/(funnel)/components/ErrorScreen/ErrorScreen';
+import LoadingScreen from '@/app/(funnel)/components/LoadingScreen/LoadingScreen';
+import errorStyles from '@/app/resync/scraping/error.module.scss';
+
+// 잡 완료 시 네이티브로 보내는 신호. webview 환경 아니면 fallback 으로 main 이동.
+// 프로토콜 합의는 docs/mpa-school-link-handoff.md 참조.
+const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
+
+const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없어요\n다시 로그인해주세요';
+
+export default function MpaPortalLoginScrapingPage() {
+  const router = useInternalRouter();
+
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [isJobIdResolved, setIsJobIdResolved] = useState(false);
+
+  useEffect(() => {
+    setJobId(sessionStorage.getItem(PORTAL_LOGIN_JOB_ID_KEY));
+    setIsJobIdResolved(true);
+  }, []);
+
+  const { data: jobStatusData, isTimedOut } = usePortalLinkJobPolling(jobId);
+  const jobStatus = jobStatusData?.data?.status;
+  const jobDetail = jobStatusData?.data;
+
+  const clearJobId = useCallback(() => {
+    sessionStorage.removeItem(PORTAL_LOGIN_JOB_ID_KEY);
+    setJobId(null);
+  }, []);
+
+  useEffect(() => {
+    if (jobStatus !== 'succeeded') {
+      return;
+    }
+    clearJobId();
+    clearRetry();
+    if (isInWebView()) {
+      postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+    } else {
+      router.push(ROUTES.MAIN);
+    }
+  }, [jobStatus, router, clearJobId]);
+
+  const { failureMessage } = usePortalLinkFailure({
+    jobStatus,
+    jobDetail,
+    isTimedOut,
+    loginRoute: ROUTES.MPA.PORTAL_LOGIN,
+    onCleanup: clearJobId,
+  });
+
+  const handleRetry = () => {
+    router.push(ROUTES.MPA.PORTAL_LOGIN);
+  };
+
+  if (isJobIdResolved && !jobId) {
+    return (
+      <div className={errorStyles.container}>
+        <ErrorScreen errorMessage={MISSING_JOB_MESSAGE} />
+        <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
+      </div>
+    );
+  }
+
+  if (failureMessage) {
+    return (
+      <div className={errorStyles.container}>
+        <ErrorScreen errorMessage={failureMessage} />
+        <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
+      </div>
+    );
+  }
+
+  return <LoadingScreen />;
+}

--- a/src/app/resync/login/page.module.scss
+++ b/src/app/resync/login/page.module.scss
@@ -5,6 +5,10 @@
 
 .container {
   @include utilities.funnel-page-spacing;
+  // iOS WebView 에서 키보드가 올라올 때 비밀번호 입력칸이 가려지지 않도록
+  // 페이지 하단에 스크롤 여유를 확보한다. position: fixed 버튼이 키보드와 함께
+  // 시야를 막는 구조라, 입력 필드가 키보드 위로 스크롤될 수 있는 영역이 필요.
+  padding-bottom: 360px;
 }
 
 .formContainer {

--- a/src/constants/portal-link.ts
+++ b/src/constants/portal-link.ts
@@ -1,1 +1,2 @@
 export const RESYNC_JOB_ID_KEY = 'resync_job_id';
+export const PORTAL_LOGIN_JOB_ID_KEY = 'portal_login_job_id';

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -20,8 +20,8 @@ export const ROUTES = {
   SETTING: '/setting',
   DELETE: '/delete',
   // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트.
-  // HOME/ME, GRADUATION_PROGRESS, RESYNC_LOGIN/RESYNC_SCRAPING 은 Next.js 페이지로 실재하며
-  // 네이티브가 webview 로 직접 로드한다.
+  // HOME/ME, GRADUATION_PROGRESS, RESYNC_LOGIN/RESYNC_SCRAPING, PORTAL_LOGIN/PORTAL_LOGIN_SCRAPING
+  // 은 Next.js 페이지로 실재하며 네이티브가 webview 로 직접 로드한다.
   // DELETE 는 Next.js 페이지가 없는 JS bridge dispatch key 로, navigateNative()
   // 송출 시 네이티브가 자체 화면/액션으로 해석한다.
   MPA: {
@@ -30,6 +30,8 @@ export const ROUTES = {
     GRADUATION_PROGRESS: '/mpa/graduation-progress',
     RESYNC_LOGIN: '/mpa/resync/login',
     RESYNC_SCRAPING: '/mpa/resync/scraping',
+    PORTAL_LOGIN: '/mpa/portal-login',
+    PORTAL_LOGIN_SCRAPING: '/mpa/portal-login/scraping',
     DELETE: '/mpa/delete',
   },
 } as const;


### PR DESCRIPTION
## Summary
- `/mpa/resync/login` 과 동일한 폼·동일한 잡 폴링이지만 별도 entry point로 `/mpa/portal-login` 추가
- `PORTAL_LOGIN_JOB_ID_KEY`로 sessionStorage 키 분리 → 두 라우트가 잡 id 를 서로 잘못 픽업하는 사고 차단
- succeeded 시 송출하는 브릿지 메시지 `done:portal-link`는 기존 프로토콜 재사용 (docs/mpa-school-link-handoff.md M3)

## Changes
- `src/app/(mpa)/mpa/portal-login/page.tsx` (신규)
- `src/app/(mpa)/mpa/portal-login/scraping/page.tsx` (신규)
- `src/constants/portal-link.ts` — `PORTAL_LOGIN_JOB_ID_KEY` 추가
- `src/constants/routes.ts` — `MPA.PORTAL_LOGIN`, `MPA.PORTAL_LOGIN_SCRAPING` 라우트 등록 및 주석 갱신

## Test plan
- [ ] WebView에서 `/mpa/portal-login` 진입 → 포털 로그인 폼이 정상 노출
- [ ] 폼 제출 후 `/mpa/portal-login/scraping`으로 이동하여 잡 폴링 정상 동작
- [ ] succeeded 시 `done:portal-link` 브릿지 메시지가 네이티브로 송출
- [ ] `/mpa/resync/login` 과 sessionStorage 키가 분리되어 잡 id 충돌 없음
- [ ] 기존 `/mpa/resync/login` 플로우 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 포털 연동 로그인 기능 추가: 사용자명/비밀번호 입력을 통한 포털 계정 연동
  * 로그인 상태 모니터링 기능 추가: 포털 연동 요청 진행 상황 실시간 추적
  * 실패 처리 및 재시도 기능 추가: 연동 실패 시 사용자 안내 및 재시도 옵션 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gyumong/chukchuk-haksa/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->