### PR TITLE
fix(mpa): probe isPortalLinked on session creation, keep GET as fallback

### DIFF
--- a/docs/mpa-school-link-handoff.md
+++ b/docs/mpa-school-link-handoff.md
@@ -42,7 +42,7 @@
 
 **B1 도입 전까지의 노출 면**
 - `POST /api/session` 은 임의의 ac/re 토큰을 그대로 봉인 → 위조 호출 시 쓰레기 cchaksa_session 발급 가능 (백엔드 호출은 401 로 차단되지만 쿠키 자체는 30일 유효)
-- `isPortalLinked` 는 POST 요청 바디에서 받지 않고 항상 `false` 강제 → 위조 호출이 portal-link 통과 상태로 세션 승격하는 경로 차단. 실제 연동 상태는 **`GET /api/session` 핸들러가 백엔드 `GET /api/student/profile` 를 probe (3s timeout) 해서 200 응답 시 세션을 `true` 로 승격**. 한 번 승격되면 이후 호출은 추가 probe 없이 즉시 응답. 재로그인(auth callback) 경로에서도 동일하게 갱신됨
+- `isPortalLinked` 는 POST 요청 바디에서 받지 않고 백엔드 probe 결과로 결정 → 위조 호출이 portal-link 통과 상태로 세션 승격하는 경로 차단. **`POST /api/session` 핸들러가 sealData 직전 백엔드 `GET /api/student/profile` 를 probe (3s timeout) 해서 200 응답 시 세션을 `true` 로 봉인.** POST probe 가 실패(타임아웃·네트워크)하면 `false` 로 봉인되고, 이후 `GET /api/session` 호출에서 동일한 probe 로 재시도 (fallback). 한 번 승격되면 추가 probe 없이 즉시 응답. 재로그인(auth callback) 경로에서도 동일하게 갱신됨
 - 발급 시점 CSRF 1차 보호: HTTPS + JSON 본문 요구 + same-origin/CORS 로 외부 페이지의 자동 POST 차단. (SameSite=Lax / HttpOnly 는 *발급된* cchaksa_session 의 후속 보호이지 발급 시점 방어선이 아님 — 서버측 `Origin` 헤더 검증 추가는 후속 강화 트랙)
 
 **재도입 트리거** (필요 시 git history 에서 게이트 코드 복원)

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -7,10 +7,10 @@ export const dynamic = 'force-dynamic';
 
 const PORTAL_LINKED_PROBE_TIMEOUT_MS = 3_000;
 
-// POST /api/session 은 보안상 isPortalLinked=false 로 강제 저장한다.
-// 실제 연동 상태는 백엔드만 알기 때문에, hydrate 시점(GET)에 backend profile 을
-// 한 번 probe 해서 200 이면 세션을 true 로 승격한다. 한 번 승격되면 이후 호출은
-// 추가 백엔드 호출 없이 즉시 응답한다.
+// isPortalLinked 는 클라이언트가 전달한 값을 신뢰하지 않고, 백엔드 probe 결과로만 결정한다.
+// POST 시점(세션 생성)에서도 probe 를 실행해 첫 응답부터 정확한 값을 반환하며,
+// POST probe 가 실패(타임아웃·네트워크)한 경우 GET 핸들러가 동일한 probe 로 재시도(fallback)한다.
+// 한 번 true 로 승격되면 이후 호출은 추가 백엔드 호출 없이 즉시 응답한다.
 async function probePortalLinked(accessToken: string): Promise<boolean> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), PORTAL_LINKED_PROBE_TIMEOUT_MS);
@@ -70,8 +70,8 @@ interface SessionExchangeBody {
 
 // 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
 // 시퀀스: docs/mpa-school-link-handoff.md
-// isPortalLinked 는 요청 바디에서 받지 않고 false 로 강제. 클라이언트 임의 값으로 세션 승격되는 경로 차단.
-// 실제 연동 상태는 GET /api/session 의 backend profile probe 또는 재로그인(auth callback) 으로 갱신됨.
+// isPortalLinked 는 요청 바디에서 받지 않고 백엔드 probe 결과로 결정 — 클라이언트 임의 값으로
+// 세션 승격되는 경로 차단. probe 가 실패하면 false 로 저장되고 GET 핸들러가 다음 호출 때 재시도.
 // TODO(backend): 토큰 진위 검증 엔드포인트가 추가되면 sealData 직전 호출해 위조 토큰 차단.
 export async function POST(request: Request) {
   let body: SessionExchangeBody;
@@ -90,11 +90,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'MISSING_REFRESH_TOKEN' }, { status: 400 });
   }
 
+  const isPortalLinked = await probePortalLinked(accessToken);
+
   const session = await getSession();
   session.accessToken = accessToken;
   session.refreshToken = refreshToken;
-  session.isPortalLinked = false;
+  session.isPortalLinked = isPortalLinked;
   await session.save();
 
-  return NextResponse.json({ ok: true, isPortalLinked: false });
+  return NextResponse.json({ ok: true, isPortalLinked });
 }


### PR DESCRIPTION
## Summary
- `POST /api/session` 핸들러가 sealData 직전에 backend `GET /api/student/profile` probe 를 실행해 첫 응답부터 정확한 `isPortalLinked` 값을 반환
- 기존엔 POST 시 무조건 `false` 봉인 후 GET 호출 때 probe 로 승격하던 구조라, GET probe 가 타임아웃/실패하면 `isPortalLinked` 가 영영 `false` 로 남는 문제 발생
- GET probe 는 fallback 으로 유지 — POST probe 실패(타임아웃·네트워크) 시 다음 GET 에서 재시도

## Why
네이티브 앱이 `/mpa/home` 진입 시 포털 미연동 다이얼로그 노출 여부를 `isPortalLinked` 로 판단하는데, 현재 항상 `false` 로 내려와서 분기 로직이 동작하지 않음. POST 시점에 probe 를 끌어다 쓰면 백엔드 변경 없이 첫 응답부터 올바른 값을 줄 수 있음.

## 보안
- 클라이언트가 보낸 `isPortalLinked` 값은 여전히 무시 — 백엔드 probe 결과만 신뢰
- 위조 토큰으로 임의 승격되는 경로 차단 유지
- 토큰 진위 검증 전용 엔드포인트(docs B1) 가 도입되면 probe 대신 verify 호출로 대체 예정

## Changes
- `src/app/api/session/route.ts` — POST 핸들러에 `probePortalLinked(accessToken)` 호출 추가, 응답에 실제 값 반환
- `docs/mpa-school-link-handoff.md` — 새 흐름 반영

## Test plan
- [ ] 신규 사용자 (미연동) 로 `POST /api/session` 호출 → 응답 `isPortalLinked: false`
- [ ] 연동 사용자 로 `POST /api/session` 호출 → 응답 `isPortalLinked: true`
- [ ] POST probe 가 타임아웃(>3s) 났을 때 → `false` 저장됨, 이후 `GET /api/session` 호출 시 재시도되어 `true` 로 승격
- [ ] 위조 accessToken 으로 POST 호출 → backend probe 가 401 반환 → `isPortalLinked: false`
- [ ] 웹 OAuth 콜백 경로(`/auth/callback`) 회귀 없음 — 해당 경로는 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)