### PR TITLE
fix(api): retry customFetch once on TypeError to recover WKWebView stale connections

### DIFF
--- a/src/shared/api/configs/httpConfig.ts
+++ b/src/shared/api/configs/httpConfig.ts
@@ -5,6 +5,22 @@ import type { ApiConfig } from '../http-client';
 
 const BASE_URL = getApiBaseUrl();
 
+// iOS WKWebView 가 connection pool 에 남은 죽은 connection 을 재사용할 때 즉시 TCP RST 를
+// 받아 `TypeError: Load failed` 를 ~10ms 만에 throw 하는 케이스가 관측됨 (Sentry CCHAKSA-56).
+// AWS API Gateway 처럼 짧은 idle timeout 을 가진 백엔드에서 흔하고, Chromium 은 자체 retry
+// 로 가려지지만 WebKit 은 노출됨. 한 번 재시도하면 새 connection 이 만들어져 풀의 stale
+// entry 를 우회 → 일시적 NETWORK_ERROR 회복. 두 번째도 throw 면 진짜 망 문제로 보고 propagate.
+async function fetchWithStaleConnRetry(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(input, init);
+  } catch (err: unknown) {
+    if (err instanceof TypeError) {
+      return fetch(input, init);
+    }
+    throw err;
+  }
+}
+
 export const createApiConfig = (): ApiConfig => ({
   baseUrl: BASE_URL,
   securityWorker: async () => {
@@ -24,7 +40,7 @@ export const createApiConfig = (): ApiConfig => ({
   },
   customFetch: async (input, init) => {
     try {
-      let response = await fetch(input, init);
+      let response = await fetchWithStaleConnRetry(input, init);
 
       if (response.status === 401) {
         const headers = new Headers(init?.headers);
@@ -32,7 +48,7 @@ export const createApiConfig = (): ApiConfig => ({
           const newAccessToken = await refreshAccessTokenStore();
           if (newAccessToken) {
             headers.set('Authorization', `Bearer ${newAccessToken}`);
-            response = await fetch(input, { ...init, headers });
+            response = await fetchWithStaleConnRetry(input, { ...init, headers });
           }
         }
       }


### PR DESCRIPTION
## Summary
`customFetch` 가 `TypeError` (fetch 자체가 throw 한 케이스) 를 catch 하면 한 번 재시도하도록 변경. iOS WKWebView 가 connection pool 에 남은 죽은 connection 을 재사용할 때 발생하는 일시적 NETWORK_ERROR 를 회복하기 위함.

## Why — Sentry CCHAKSA-56
- **TypeError: Load failed** 가 iOS 앱 WebView 에서 `/mpa/home` 진입 시 발생, **62 events / 33 users / 12일** 지속
- 실패 URL: `https://dev.api.cchaksa.com/api/academic/summary`
- **throw 시점이 fetch 발사 후 ~10ms** → 요청이 망까지 안 나갔거나 즉시 RST 받음
- CORS preflight/응답 모두 정상 (`access-control-allow-origin: https://dv.cchaksa.com`, `access-control-allow-credentials: true`)
- 같은 iPhone 의 Safari 는 정상, 같은 코드의 Android WebView 도 정상
- 앱 재설치 시 일시적으로 정상화 → 시간 지나면 재발

## 원인 추정
AWS API Gateway (`dev.api.cchaksa.com`) 가 짧은 idle timeout (보통 350초) 으로 서버측 connection close 를 하면, WebKit 의 connection pool 에 stale entry 가 남음. 이후 같은 호스트 요청이 그 죽은 connection 을 재사용 시도 → 즉시 RST → `TypeError: Load failed`. Chromium 은 자체 race/retry 로 가려지지만 WebKit 은 폴백이 약함.

증상 매트릭스:

| 환경 | 결과 | 이유 |
|---|---|---|
| iOS Safari | OK | 별도 프로세스 pool |
| iOS WKWebView | NG | 본 PR 대상 |
| Android WebView | OK | Chromium 의 robust retry |
| 첫 설치 직후 | OK | pool 비어있음 |
| 시간 지난 후 | NG | stale connection 누적 |
| 앱 데이터 리셋 후 | OK | pool wipe |

## Changes
- `src/shared/api/configs/httpConfig.ts` — `fetchWithStaleConnRetry` 헬퍼 추가. `customFetch` 의 초기 fetch 와 401 refresh 후 재시도 양쪽에 적용

## Trade-off
두 번째 fetch 가 새 connection 으로 같은 요청을 보내므로 POST 같은 비-멱등 요청은 이론상 중복 실행 가능성 있음. 다만:
- `TypeError` throw 는 서버 응답 미도달 신호 → 서버 처리도 안 됐을 가능성이 높음
- 멱등성 중요 경로 (portal-link 등) 는 기존 `generateIdempotencyKey` 로 방어됨
- 이득 (62 events 회복) > 위험 (이론적 중복) 으로 판단

## Test plan
- [ ] 로컬에서 정상 트래픽 회귀 없음 (lint/type-check 통과 확인됨)
- [ ] 디버그 빌드로 iPhone WKWebView 에 배포 → 시간 두고 사용 후 `/mpa/home` 진입 시 NETWORK_ERROR 화면 재현되지 않음 확인
- [ ] Sentry CCHAKSA-56 이벤트 발생률 감소 추이 모니터링 (배포 후 며칠)
- [ ] 두 번째 시도도 실패하는 케이스는 기존대로 Sentry 캡처 후 fallback UI

## Follow-ups (별도 트랙)
- 백엔드 팀: AWS API Gateway 앞 ALB 도입 또는 idle timeout 조정 검토 (server hint 로 클라이언트가 stale 인지하도록)
- 모니터링: 재시도 발생률을 더 정밀하게 보고 싶다면 `fetchWithStaleConnRetry` 의 성공한 retry 도 info 레벨로 캡처 옵션 추가 가능 (Sentry 쿼터 고려 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)