### PR TITLE
fix(auth): harden session refresh + expiry recovery across all clients

### DIFF
--- a/src/app/api/session/refresh/route.ts
+++ b/src/app/api/session/refresh/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getSession } from '@/lib/auth/session';
-import { getApiBaseUrl } from '@/config/environment';
-import type { RefreshTokenApiResponse } from '@/shared/api/data-contracts';
+import { refreshTokensFromBackend } from '@/lib/auth/refreshToken';
 
 export const dynamic = 'force-dynamic';
-
-const REFRESH_TIMEOUT_MS = 10_000;
 
 export async function POST() {
   const session = await getSession();
@@ -14,43 +11,18 @@ export async function POST() {
     return NextResponse.json({ error: 'NO_REFRESH_TOKEN' }, { status: 401 });
   }
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+  const refreshed = await refreshTokensFromBackend(session.refreshToken);
 
-  try {
-    const response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ refreshToken: session.refreshToken }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      session.destroy();
-      return NextResponse.json({ error: 'REFRESH_FAILED' }, { status: 401 });
-    }
-
-    const payload = (await response.json()) as RefreshTokenApiResponse;
-
-    if (!payload.success || !payload.data?.accessToken || !payload.data?.refreshToken) {
-      session.destroy();
-      return NextResponse.json({ error: 'REFRESH_FAILED' }, { status: 401 });
-    }
-
-    session.accessToken = payload.data.accessToken;
-    session.refreshToken = payload.data.refreshToken;
-    await session.save();
-
-    return NextResponse.json({ accessToken: payload.data.accessToken });
-  } catch (error) {
+  if (!refreshed) {
+    // 백엔드 거부·타임아웃·형식 오류 모두 회복 불가로 보고 세션 폐기.
+    // 클라이언트가 SESSION_EXPIRED 응답을 받아 로그아웃 흐름으로 진입한다.
     session.destroy();
-    if (error instanceof DOMException && error.name === 'AbortError') {
-      console.error('[session/refresh] timed out after', REFRESH_TIMEOUT_MS, 'ms');
-      return NextResponse.json({ error: 'REFRESH_TIMEOUT' }, { status: 504 });
-    }
-    console.error('[session/refresh] unexpected error', error);
-    return NextResponse.json({ error: 'REFRESH_ERROR' }, { status: 500 });
-  } finally {
-    clearTimeout(timeoutId);
+    return NextResponse.json({ error: 'REFRESH_FAILED' }, { status: 401 });
   }
+
+  session.accessToken = refreshed.accessToken;
+  session.refreshToken = refreshed.refreshToken;
+  await session.save();
+
+  return NextResponse.json({ accessToken: refreshed.accessToken });
 }

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,19 +1,25 @@
 import { NextResponse } from 'next/server';
 import { captureException } from '@sentry/nextjs';
 import { getSession } from '@/lib/auth/session';
+import { refreshTokensFromBackend } from '@/lib/auth/refreshToken';
 import { getApiBaseUrl } from '@/config/environment';
 
 export const dynamic = 'force-dynamic';
 
-const PORTAL_LINKED_PROBE_TIMEOUT_MS = 3_000;
+const STUDENT_PROFILE_PROBE_TIMEOUT_MS = 3_000;
 
-// isPortalLinked 는 클라이언트가 전달한 값을 신뢰하지 않고, 백엔드 probe 결과로만 결정한다.
-// POST 시점(세션 생성)에서도 probe 를 실행해 첫 응답부터 정확한 값을 반환하며,
-// POST probe 가 실패(타임아웃·네트워크)한 경우 GET 핸들러가 동일한 probe 로 재시도(fallback)한다.
-// 한 번 true 로 승격되면 이후 호출은 추가 백엔드 호출 없이 즉시 응답한다.
-async function probePortalLinked(accessToken: string): Promise<boolean> {
+type ProbeResult = 'ok' | 'unauthorized' | 'error';
+
+// 백엔드 `/api/student/profile` 호출 결과를 세 종류로 분류해서 반환한다.
+// - 'ok' (200)            → accessToken 유효 + 사용자가 portal-link 완료된 상태
+// - 'unauthorized' (401)  → accessToken 만료/무효. refresh 가 필요한 신호
+// - 'error' (그 외)       → 백엔드/네트워크 일시 오류. 상태 변경 없이 fallback 으로 처리
+//
+// GET 에서 토큰 유효성 검증과 isPortalLinked 승격을 한 번의 백엔드 호출로 수행하고,
+// POST 에서 세션 생성 시 isPortalLinked 초기값을 결정한다.
+async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), PORTAL_LINKED_PROBE_TIMEOUT_MS);
+  const timeoutId = setTimeout(() => controller.abort(), STUDENT_PROFILE_PROBE_TIMEOUT_MS);
   try {
     const response = await fetch(`${getApiBaseUrl()}/api/student/profile`, {
       method: 'GET',
@@ -21,21 +27,34 @@ async function probePortalLinked(accessToken: string): Promise<boolean> {
       signal: controller.signal,
       cache: 'no-store',
     });
-    return response.ok;
+    if (response.status === 401) {
+      return 'unauthorized';
+    }
+    if (response.ok) {
+      return 'ok';
+    }
+    return 'error';
   } catch (error) {
-    // 타임아웃(AbortError)은 예상된 경로라 캡처하지 않고, 그 외 네트워크/예외만 관측한다.
     if (!(error instanceof Error && error.name === 'AbortError')) {
       captureException(error, {
-        tags: { scope: 'session', action: 'probePortalLinked' },
-        extra: { endpoint: '/api/student/profile', timeoutMs: PORTAL_LINKED_PROBE_TIMEOUT_MS },
+        tags: { scope: 'session', action: 'probeStudentProfile' },
+        extra: { endpoint: '/api/student/profile', timeoutMs: STUDENT_PROFILE_PROBE_TIMEOUT_MS },
       });
     }
-    return false;
+    return 'error';
   } finally {
     clearTimeout(timeoutId);
   }
 }
 
+// GET /api/session: 클라이언트 하이드레이션 진입점.
+// 1. 쿠키에서 토큰 꺼냄
+// 2. 백엔드 probe 로 유효성 검증
+// 3. 만료(401) 이고 refreshToken 있으면 서버 측에서 refresh 실행 → 다시 probe
+// 4. 회복 불가능하면 세션 폐기 후 401 응답 → 클라이언트가 로그아웃 흐름 진입
+//
+// 이로써 클라이언트가 만료된 토큰으로 첫 API 호출하다 401 받아 fallback UI 도배되는 케이스를 차단.
+// isPortalLinked 는 probe 결과(`'ok'`)로만 true 로 승격 — 클라이언트 임의 값 신뢰 안 함.
 export async function GET() {
   const session = await getSession();
 
@@ -43,13 +62,34 @@ export async function GET() {
     return NextResponse.json({ error: 'UNAUTHENTICATED' }, { status: 401 });
   }
 
-  if (session.isPortalLinked !== true) {
-    const linked = await probePortalLinked(session.accessToken);
-    if (linked) {
-      session.isPortalLinked = true;
-      await session.save();
+  let probe = await probeStudentProfile(session.accessToken);
+
+  if (probe === 'unauthorized') {
+    const refreshed = session.refreshToken ? await refreshTokensFromBackend(session.refreshToken) : null;
+
+    if (!refreshed) {
+      session.destroy();
+      return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
+    }
+
+    session.accessToken = refreshed.accessToken;
+    session.refreshToken = refreshed.refreshToken;
+
+    // 새 토큰으로 probe 재시도 — 유효성 재확인 + isPortalLinked 판단.
+    probe = await probeStudentProfile(session.accessToken);
+
+    if (probe === 'unauthorized') {
+      // refresh 가 발급한 토큰조차 거부 → 백엔드 상태 이상. 세션 폐기.
+      session.destroy();
+      return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
     }
   }
+
+  if (probe === 'ok' && session.isPortalLinked !== true) {
+    session.isPortalLinked = true;
+  }
+
+  await session.save();
 
   return NextResponse.json({
     accessToken: session.accessToken,
@@ -71,7 +111,7 @@ interface SessionExchangeBody {
 // 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
 // 시퀀스: docs/mpa-school-link-handoff.md
 // isPortalLinked 는 요청 바디에서 받지 않고 백엔드 probe 결과로 결정 — 클라이언트 임의 값으로
-// 세션 승격되는 경로 차단. probe 가 실패하면 false 로 저장되고 GET 핸들러가 다음 호출 때 재시도.
+// 세션 승격되는 경로 차단. probe 가 일시 실패(`'error'`)면 false 로 저장되고, 다음 GET 에서 재시도.
 // TODO(backend): 토큰 진위 검증 엔드포인트가 추가되면 sealData 직전 호출해 위조 토큰 차단.
 export async function POST(request: Request) {
   let body: SessionExchangeBody;
@@ -90,7 +130,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'MISSING_REFRESH_TOKEN' }, { status: 400 });
   }
 
-  const isPortalLinked = await probePortalLinked(accessToken);
+  const probe = await probeStudentProfile(accessToken);
+  const isPortalLinked = probe === 'ok';
 
   const session = await getSession();
   session.accessToken = accessToken;

--- a/src/features/auth/components/ProtectedRoute.tsx
+++ b/src/features/auth/components/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAuth } from '../contexts/AuthContext';
 import { useAuthCheck } from '../hooks/useAuthCheck';
 
 import type { RoutePath } from '@/hooks/useInternalRouter';
@@ -18,8 +19,12 @@ const ProtectedRoute = ({
   portalLinkRedirectTo,
 }: ProtectedRouteProps) => {
   const isChecking = useAuthCheck(redirectTo, requirePortalLinked, portalLinkRedirectTo);
+  const { accessToken, isPortalLinked } = useAuth();
 
-  if (isChecking) {
+  // 토큰이 마운트 이후 만료/refresh 실패로 null 이 된 케이스에서도 children 을 즉시 unmount.
+  // useAuthCheck 의 redirect 가 트리거되는 동안 자식 컴포넌트가 만료된 토큰으로 API 호출해
+  // 401/NETWORK_ERROR fallback 이 깜빡이는 것을 막는다. requirePortalLinked 도 동일 원리.
+  if (isChecking || !accessToken || (requirePortalLinked && isPortalLinked === false)) {
     return <></>;
   }
 

--- a/src/features/auth/contexts/AuthContext.tsx
+++ b/src/features/auth/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { queryClient } from '@/shared/api/configs/queryClient';
 import {
   getAccessTokenStore,
   refreshAccessTokenStore,
@@ -26,6 +27,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     return subscribeAccessTokenStore(token => setAccessTokenState(token));
   }, []);
+
+  // 인증된 적 있다가 token 이 null 로 떨어진 경우 (= 만료 → refresh 실패) React Query 캐시 wipe.
+  // 보호 페이지가 unmount 되는 동안 stale 데이터를 다음 세션이 잘못 재사용하는 사고 방지.
+  const previousTokenRef = useRef<string | null>(accessToken);
+  useEffect(() => {
+    if (previousTokenRef.current !== null && accessToken === null) {
+      queryClient.clear();
+    }
+    previousTokenRef.current = accessToken;
+  }, [accessToken]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/features/auth/hooks/useAuthCheck.ts
+++ b/src/features/auth/hooks/useAuthCheck.ts
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 import { useInternalRouter, type RoutePath } from '@/hooks/useInternalRouter';
 import { useAuth } from '../contexts/AuthContext';
 
+// 마운트 이후에도 accessToken 이 null 로 전이하면 (만료 → refresh 실패 등) 즉시 redirect.
+// router.replace 사용 — 만료된 보호 페이지가 히스토리에 남아 뒤로가기로 돌아가는 사고 방지.
 export function useAuthCheck(
   redirectTo: RoutePath = '/',
   requirePortalLinked: boolean = false,
@@ -14,12 +16,12 @@ export function useAuthCheck(
     if (!isReady) {return;}
 
     if (!accessToken) {
-      router.push(redirectTo);
+      router.replace(redirectTo);
       return;
     }
 
     if (requirePortalLinked && isPortalLinked === false) {
-      router.push(portalLinkRedirectTo);
+      router.replace(portalLinkRedirectTo);
     }
   }, [accessToken, isPortalLinked, isReady, redirectTo, requirePortalLinked, portalLinkRedirectTo, router]);
 

--- a/src/lib/auth/refreshToken.ts
+++ b/src/lib/auth/refreshToken.ts
@@ -1,0 +1,52 @@
+import { getApiBaseUrl } from '@/config/environment';
+import type { RefreshTokenApiResponse } from '@/shared/api/data-contracts';
+
+export const REFRESH_TIMEOUT_MS = 10_000;
+
+export interface RefreshedTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * 백엔드 /api/auth/refresh 호출. 성공 시 새 토큰 쌍 반환, 실패·타임아웃·형식 오류 시 null.
+ *
+ * `POST /api/session/refresh` 라우트와 `GET /api/session` 핸들러(만료 토큰 자동 갱신) 모두에서
+ * 공유. 부작용 없음 — 세션 mutation 은 호출 측에서 수행한다.
+ */
+export async function refreshTokensFromBackend(refreshToken: string): Promise<RefreshedTokens | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/api/auth/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as RefreshTokenApiResponse;
+    if (!payload.success || !payload.data?.accessToken || !payload.data?.refreshToken) {
+      return null;
+    }
+
+    return {
+      accessToken: payload.data.accessToken,
+      refreshToken: payload.data.refreshToken,
+    };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      console.error('[refreshTokensFromBackend] timed out after', REFRESH_TIMEOUT_MS, 'ms');
+    } else {
+      console.error('[refreshTokensFromBackend] unexpected error', error);
+    }
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/shared/components/error-fallback/ApiErrorFallback.tsx
+++ b/src/shared/components/error-fallback/ApiErrorFallback.tsx
@@ -1,9 +1,23 @@
+import { useAuth } from '@/features/auth/contexts/AuthContext';
 import type { ApiError } from '@/shared/api/errors';
 import { getUserMessage } from '@/shared/user-messages';
 import type { FallbackProps } from '../ErrorBoundary';
 
 const ApiErrorFallback = ({ error, reset }: FallbackProps) => {
   const apiError = error as ApiError;
+  const { clearAuth } = useAuth();
+
+  // 401 = 인증 만료. 일반 재시도가 의미 없으므로 세션 정리 + 로그인 페이지 안내.
+  // (refresh 가 가능했다면 customFetch / GET /api/session 단계에서 이미 처리됐을 것)
+  if (apiError.status === 401) {
+    return (
+      <div>
+        <h2>세션이 만료되었습니다</h2>
+        <p>보안을 위해 자동 로그아웃되었어요.{'\n'}다시 로그인해주세요.</p>
+        <button onClick={() => clearAuth()}>로그인하러 가기</button>
+      </div>
+    );
+  }
 
   return (
     <div>


### PR DESCRIPTION
## 문제

만료된 세션에서 회복 불가능한 케이스 (iOS·Android 공통). 토큰 만료/refresh 실패 시 보호 페이지(/mpa/home 등)의 카드들이 401/NETWORK_ERROR fallback 으로 도배되어 사용자가 갇힘. iOS 에서 더 자주 노출됐지만 **Android 도 동일 시한폭탄** — refresh 로직 자체가 플랫폼 무관 결함.

## 4가지 근본 결함과 처방

### 1. 세션 hydration 시 토큰 유효성 검증 안 함 → 모든 카드가 첫 호출에서 401 폭주
**Before**: `GET /api/session` 이 쿠키에서 accessToken 꺼내 그대로 반환 (만료 여부 무관). 클라이언트는 만료된 토큰으로 첫 API 호출 → 401 → 그제서야 customFetch 가 refresh 트리거.
**After**: 매 hydration 마다 백엔드 probe 로 유효성 검증 → 401 이면 서버 측에서 즉시 refresh → 새 토큰을 클라이언트에 내려줌. 클라이언트는 항상 fresh 토큰으로 시작.

### 2. Refresh 실패해도 사용자를 못 내보냄 → 화면 도배 후 멈춤
**Before**: refresh 실패 시 `setAccessTokenStore(null)` 만 호출. `useAuthCheck` 의 redirect 는 마운트 시 1회만이라 이후 token 상실 케이스 못 잡음.
**After**: `ProtectedRoute` 가 accessToken/isPortalLinked 변화에 즉시 반응해 children unmount. `useAuthCheck` 는 router.replace 로 히스토리 깨끗하게.

### 3. Stale React Query 데이터가 다음 세션으로 누출
**Before**: 로그아웃/만료 후 cache 그대로. 다른 계정으로 로그인하면 이전 사용자 데이터가 잠깐 보일 수 있음.
**After**: `AuthContext` 가 accessToken 의 non-null → null 전이 시 `queryClient.clear()`.

### 4. 401 에러 UI 가 일반 NETWORK_ERROR 와 구분 안 됨
**Before**: 401 도 일반 NETWORK_ERROR 와 같은 "다시 시도" fallback. 사용자가 영영 갇힘.
**After**: status 401 일 때 "세션이 만료되었습니다" + 로그인 버튼 분기. clearAuth() 호출로 깔끔한 로그아웃 흐름 진입.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/lib/auth/refreshToken.ts` (신규) | 백엔드 refresh 호출 공유 헬퍼 |
| `src/app/api/session/refresh/route.ts` | 공유 헬퍼 사용으로 슬림화 |
| `src/app/api/session/route.ts` | GET 핸들러에 probe 기반 유효성 검증 + 자동 refresh. probe 함수가 `'ok' \| 'unauthorized' \| 'error'` 반환하도록 변경 (토큰 유효성과 isPortalLinked 한 호출로 처리) |
| `src/features/auth/components/ProtectedRoute.tsx` | accessToken/isPortalLinked 변화 시 즉시 unmount |
| `src/features/auth/hooks/useAuthCheck.ts` | router.push → router.replace |
| `src/features/auth/contexts/AuthContext.tsx` | accessToken 상실 시 React Query cache wipe |
| `src/shared/components/error-fallback/ApiErrorFallback.tsx` | 401 분기 UI + 로그인 버튼 |

## iOS / Android 공통 적용

본 변경은 플랫폼 무관 (tokenStore 메모리·refresh 트리거·hydration·redirect 모두 동일 로직). 그동안 iOS WKWebView 에서 더 빨리 노출됐지만 Android 도 토큰 충분히 묵히면 같은 케이스 발생. 이번 PR 로 양쪽 동시 처방.

## Test plan

- [ ] 정상 사용자 흐름 회귀 — `/mpa/home` 진입, 모든 카드 정상 로드
- [ ] 만료된 accessToken + 유효한 refreshToken — 서버 측에서 자동 refresh, 사용자는 인지 못 함
- [ ] 만료된 refreshToken — `/api/session` 이 401 SESSION_EXPIRED 반환, 클라이언트는 랜딩 페이지로 redirect
- [ ] 사용 중 토큰 만료 (페이지 머무는 동안 backend 가 401) — customFetch refresh 시도 → 실패하면 ApiErrorFallback 의 401 분기 노출
- [ ] 401 fallback 에서 로그인 버튼 클릭 → 세션 정리되고 랜딩으로 이동
- [ ] 로그아웃 후 다른 계정 로그인 → 이전 사용자 데이터 잔류 없음 (queryClient.clear 확인)
- [ ] `/api/session/refresh` 직접 호출 회귀 (httpConfig customFetch 의 401 retry 경로) — 동작 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)