### PR TITLE
fix(auth): trigger refresh on probe 'error' too, recover from backend expired-JWT hang

### DIFF
--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -50,10 +50,16 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
 // GET /api/session: 클라이언트 하이드레이션 진입점.
 // 1. 쿠키에서 토큰 꺼냄
 // 2. 백엔드 probe 로 유효성 검증
-// 3. 만료(401) 이고 refreshToken 있으면 서버 측에서 refresh 실행 → 다시 probe
-// 4. 회복 불가능하면 세션 폐기 후 401 응답 → 클라이언트가 로그아웃 흐름 진입
+// 3. probe 가 명시적 401 또는 'error'(타임아웃·5xx) 이고 refreshToken 있으면 서버 측에서 refresh 실행
+// 4. 회복 불가능하면 결과에 따라 분기:
+//    - 'unauthorized' + refresh 실패 → 세션 폐기 + 401 응답 (확정 만료)
+//    - 'error' + refresh 실패        → 세션 유지 + 현재 토큰 그대로 응답 (백엔드 일시 장애 추정)
 //
-// 이로써 클라이언트가 만료된 토큰으로 첫 API 호출하다 401 받아 fallback UI 도배되는 케이스를 차단.
+// 'error' 분기에서도 refresh 시도하는 이유 — 백엔드가 만료 JWT 처리 중 hang 해서 probe 가 timeout 으로
+// 'error' 떨어지는 케이스 관측됨 (Sentry CCHAKSA-56). 이 경우 토큰이 사실상 만료라 refresh 가 필요한데
+// probe 가 401 을 못 받아서 회복 못 함. 'error' 에서도 refresh 시도하면 백엔드 hang 우회 가능
+// (refresh 엔드포인트는 expired-token hang 영향 없음). 다만 진짜 일시 장애일 수 있으니 refresh 실패 시
+// 세션은 유지.
 // isPortalLinked 는 probe 결과(`'ok'`)로만 true 로 승격 — 클라이언트 임의 값 신뢰 안 함.
 export async function GET() {
   const session = await getSession();
@@ -64,12 +70,21 @@ export async function GET() {
 
   let probe = await probeStudentProfile(session.accessToken);
 
-  if (probe === 'unauthorized') {
+  if (probe === 'unauthorized' || probe === 'error') {
     const refreshed = session.refreshToken ? await refreshTokensFromBackend(session.refreshToken) : null;
 
     if (!refreshed) {
-      session.destroy();
-      return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
+      if (probe === 'unauthorized') {
+        // 명시적 401 → 토큰 확정 만료. 세션 폐기 후 클라이언트 로그아웃 흐름.
+        session.destroy();
+        return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
+      }
+      // probe === 'error' + refresh 실패 → 백엔드 일시 장애 추정. 세션 유지, 현재 토큰 반환.
+      // 다음 GET 에서 자연스럽게 재시도됨.
+      return NextResponse.json({
+        accessToken: session.accessToken,
+        isPortalLinked: session.isPortalLinked ?? false,
+      });
     }
 
     session.accessToken = refreshed.accessToken;
@@ -83,6 +98,7 @@ export async function GET() {
       session.destroy();
       return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
     }
+    // probe === 'error' 면 새 토큰 그대로 유지 — 다음 호출에서 다시 시도.
   }
 
   if (probe === 'ok' && session.isPortalLinked !== true) {


### PR DESCRIPTION
## 배경 — Sentry CCHAKSA-56 원인 확정

curl 직접 검증으로 백엔드가 만료된 JWT 를 처리하다 hang 한다는 게 확정됐습니다:

```
인증 없이: HTTP/1.1 401 (~80ms 정상)
만료 JWT:  HTTP/1.1 502 Bad Gateway (~29초 hang)
           {"message":"Gateway Timeout"}
           Apigw-Requestid: d6hzJhpmIE0EPBw=
```

즉 Spring Boot 의 JWT 인증 필터에 만료 처리 hang 버그가 있고, AWS API Gateway integration timeout (29초) 후 502 가 반환됩니다. 그리고 5xx 응답에 CORS 헤더가 없어 WebKit 이 \`TypeError: Load failed\` 로 거부 → 5개 카드 ErrorBoundary 가 각자 fallback 노출 → NETWORK_ERROR 도배.

상세 분석: \`docs/mpa-network-error-investigation.md\`

## 본 PR 의 처방 (프론트 임시 회복)

\`GET /api/session\` 의 probe 가 \`'error'\` (타임아웃·5xx) 일 때도 refresh 시도하도록 분기 확장. 기존엔 \`'unauthorized'\` (401) 일 때만 트리거됐는데:

- 백엔드 JWT-hang 버그 때문에 BFF probe 가 \`AbortController\` 3초 timeout 으로 \`'error'\` 떨어짐
- 그 결과 refresh 안 됨 → 만료된 토큰 그대로 클라이언트에 반환 → 회복 불가

처방 적용 시:

- probe \`'error'\` → refresh 시도 (\`/api/auth/refresh\` 는 별도 refreshToken 으로 호출되어 expired-token hang 영향 없음)
- refresh 성공 → 새 fresh 토큰 발급 → 다음 호출 정상 처리
- **백엔드 hang 버그 fix 전이라도 사용자가 자동 회복**

## refresh 실패 시 분기

원래 probe 결과에 따라 다르게 처리:

| 원래 probe | refresh 실패 시 | 이유 |
|---|---|---|
| \`'unauthorized'\` | session.destroy() + 401 SESSION_EXPIRED (기존 동작) | 명시적 401 = 토큰 확정 만료 |
| \`'error'\` | 세션 유지, 현재 토큰 반환 (신규) | 백엔드 일시 장애 추정, 다음 GET 에서 자연 재시도 |

## Trade-off

- 백엔드가 진짜 일시 5xx 일 때도 매 hydration 마다 refresh 시도 → 백엔드 부하 약간 증가
- hydration 당 1회라 부담 크지 않고, 백엔드 hang 회복 가치가 압도적

## 근본 fix (별도 트랙, 백엔드/인프라)

1. **Spring Boot JWT 만료 처리 hang 수정** — \`ExpiredJwtException\` 처리 누락 점검
2. **AWS API Gateway 5xx 응답에 CORS 헤더 추가** — \`DEFAULT_5XX\`, \`INTEGRATION_TIMEOUT\` 등 Gateway Responses

상세는 \`docs/mpa-network-error-investigation.md\` 의 액션 아이템 표 참조.

## Test plan

- [ ] 정상 사용자 회귀: \`/mpa/home\` 첫 진입, 모든 카드 정상 로드
- [ ] 만료 토큰 + 백엔드 hang 시뮬레이션: probe 가 timeout 으로 \`'error'\` 떨어지면 refresh 시도 → 새 토큰 발급 → 사용자 인지 못 함
- [ ] 만료 토큰 + 백엔드 정상 시뮬레이션: probe 가 401 받으면 기존 unauthorized 분기로 refresh
- [ ] refresh 도 실패하는 경우: probe='unauthorized' → 401 SESSION_EXPIRED + redirect / probe='error' → 세션 유지
- [ ] 백엔드 신뢰성 트랙 별개 — 본 PR 머지 후 Sentry CCHAKSA-56 추이 관측

🤖 Generated with [Claude Code](https://claude.com/claude-code)