### PR TITLE
fix(auth): destroy session on any refresh failure (simplify probe error branch)

### DIFF
--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -50,16 +50,17 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
 // GET /api/session: 클라이언트 하이드레이션 진입점.
 // 1. 쿠키에서 토큰 꺼냄
 // 2. 백엔드 probe 로 유효성 검증
-// 3. probe 가 명시적 401 또는 'error'(타임아웃·5xx) 이고 refreshToken 있으면 서버 측에서 refresh 실행
-// 4. 회복 불가능하면 결과에 따라 분기:
-//    - 'unauthorized' + refresh 실패 → 세션 폐기 + 401 응답 (확정 만료)
-//    - 'error' + refresh 실패        → 세션 유지 + 현재 토큰 그대로 응답 (백엔드 일시 장애 추정)
+// 3. probe 가 'ok' 가 아니면(만료·timeout·5xx 등) refresh 시도
+// 4. refresh 실패 시 세션 폐기 + 401 응답 → 클라이언트가 로그아웃 흐름 진입
 //
-// 'error' 분기에서도 refresh 시도하는 이유 — 백엔드가 만료 JWT 처리 중 hang 해서 probe 가 timeout 으로
-// 'error' 떨어지는 케이스 관측됨 (Sentry CCHAKSA-56). 이 경우 토큰이 사실상 만료라 refresh 가 필요한데
-// probe 가 401 을 못 받아서 회복 못 함. 'error' 에서도 refresh 시도하면 백엔드 hang 우회 가능
-// (refresh 엔드포인트는 expired-token hang 영향 없음). 다만 진짜 일시 장애일 수 있으니 refresh 실패 시
-// 세션은 유지.
+// probe 가 'error' (타임아웃·5xx) 일 때도 refresh 시도하는 이유 — 백엔드가 만료 JWT 처리 중 hang 해서
+// probe 가 401 을 못 받고 timeout 으로 'error' 떨어지는 케이스 관측됨 (Sentry CCHAKSA-56).
+// refresh 엔드포인트는 별도 refreshToken 으로 호출되어 expired-token hang 영향 없음 → 새 토큰 발급 가능.
+//
+// refresh 실패 시 분기 단순화: probe 가 'unauthorized' 든 'error' 든 무조건 세션 폐기.
+// 사용자가 깨진 화면에 갇히는 것보다 로그인 화면으로 보내는 게 명확. 진짜 백엔드 일시 장애여도
+// 로그인 시도 자체가 분명한 액션을 제공 (정상이면 재로그인 후 정상, 백엔드 다운이면 로그인도 실패해서 인지 가능).
+//
 // isPortalLinked 는 probe 결과(`'ok'`)로만 true 로 승격 — 클라이언트 임의 값 신뢰 안 함.
 export async function GET() {
   const session = await getSession();
@@ -70,21 +71,12 @@ export async function GET() {
 
   let probe = await probeStudentProfile(session.accessToken);
 
-  if (probe === 'unauthorized' || probe === 'error') {
+  if (probe !== 'ok') {
     const refreshed = session.refreshToken ? await refreshTokensFromBackend(session.refreshToken) : null;
 
     if (!refreshed) {
-      if (probe === 'unauthorized') {
-        // 명시적 401 → 토큰 확정 만료. 세션 폐기 후 클라이언트 로그아웃 흐름.
-        session.destroy();
-        return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
-      }
-      // probe === 'error' + refresh 실패 → 백엔드 일시 장애 추정. 세션 유지, 현재 토큰 반환.
-      // 다음 GET 에서 자연스럽게 재시도됨.
-      return NextResponse.json({
-        accessToken: session.accessToken,
-        isPortalLinked: session.isPortalLinked ?? false,
-      });
+      session.destroy();
+      return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
     }
 
     session.accessToken = refreshed.accessToken;


### PR DESCRIPTION
## 배경

PR #186 ('error' 분기에서도 refresh fallback) 머지 후 재현 테스트에서 여전히 사용자가 NETWORK_ERROR 도배 화면에 갇히는 케이스가 확인됐습니다.

원인 — #186 의 'error' 분기에서 refresh 가 **실패**했을 때 처리:

```ts
if (!refreshed) {
  if (probe === 'unauthorized') {
    session.destroy();
    return 401 SESSION_EXPIRED;
  }
  // probe === 'error' + refresh 실패 → 만료 토큰 그대로 반환 ← 갇힘
  return 200 with (expired) accessToken;
}
```

이 경우 클라이언트가 만료된 토큰을 받아 다시 API 호출 → 같은 hang/실패 → NETWORK_ERROR 도배 반복.

## 처방

조건 단순화: refresh 실패 시 원래 probe 결과와 무관하게 무조건 session 폐기.

```ts
// Before
if (probe === 'unauthorized' || probe === 'error') {
  const refreshed = ...
  if (!refreshed) {
    if (probe === 'unauthorized') { destroy + 401 }
    return 200 with old token;  // ← 갇힘
  }
  ...
}

// After
if (probe !== 'ok') {
  const refreshed = ...
  if (!refreshed) {
    session.destroy();
    return 401 SESSION_EXPIRED;  // ← 무조건 redirect
  }
  ...
}
```

## 새 동작 매트릭스

| probe | refresh | 결과 |
|---|---|---|
| 'ok' | (skip) | 통과 |
| 'unauthorized' | 성공 | 새 토큰으로 정상 진행 |
| 'unauthorized' | 실패 | destroy + 401 → 로그인 redirect |
| 'error' (백엔드 hang/5xx) | 성공 | 새 토큰 — 백엔드 hang 우회 |
| **'error'** | **실패** | **destroy + 401 → 로그인 redirect** (변경점) |

## Trade-off

진짜 백엔드 일시 5xx 일 때도 사용자 로그아웃됨. 다만:

- 깨진 화면에 갇히는 것보다 로그인 시도가 분명한 액션
- 백엔드 진짜 다운이면 로그인도 실패 → 사용자 인지 가능
- 정상 백엔드면 재로그인 후 fresh 상태로 정상화

## 예상 효과

- 백엔드 JWT-hang + refreshToken 만료된 사용자: 도배 갇힘 → 로그인 화면 redirect
- 백엔드 JWT-hang + refreshToken 살아있는 사용자: refresh 성공 → 인지 못 함 (#186 효과 그대로)
- 정상 사용자: 변화 없음

## Test plan

- [ ] 정상 사용자 회귀: \`/mpa/home\` 정상 동작
- [ ] 만료 토큰 + refresh 가능: 자동 회복 (인지 못 함)
- [ ] 만료 토큰 + refresh 불가: 로그인 화면 redirect (NETWORK_ERROR 도배 사라짐)
- [ ] 백엔드 일시 5xx + refresh 가능: 자동 회복
- [ ] 백엔드 일시 5xx + refresh 도 실패: 로그인 화면 redirect (acceptable trade-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)