### PR TITLE
chore: add ads.txt for AdSense site ownership verification

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6527557981566120, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Google AdSense 사이트 소유권 확인용 `public/ads.txt` 추가
- Next.js public 디렉터리에 두어 프로덕션 루트(`/ads.txt`)로 정적 서빙

## 배포 후 확인
- AdSense 콘솔에서 "ads.txt 파일을 게시함" 클릭 → Google이 `https://<prod-domain>/ads.txt` 크롤링 → 소유권 확인 완료

## Test plan
- [ ] 로컬: `yarn dev` 후 `curl http://localhost:3000/ads.txt`로 `google.com, pub-6527557981566120, DIRECT, f08c47fec0942fa0` 한 줄 확인
- [ ] 머지 후 프로덕션 도메인의 `/ads.txt`에서 동일 내용 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)