### PR TITLE
fix(auth): treat /api/student/profile 404 as 'not-linked' (correction to #195)

### DIFF
--- a/src/app/(setting)/delete/page.tsx
+++ b/src/app/(setting)/delete/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { setCookie } from 'cookies-next';
 import Image from 'next/image';
 import { FunnelHeadline } from '@/app/(funnel)/components';
 import { FixedButton } from '@/components/ui';
@@ -8,11 +7,6 @@ import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQue
 import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { useDeleteUserMutation } from '@/features/user/apis/queries/useDeleteUserMutation';
 import styles from './page.module.scss';
-
-// 탈퇴 직후 재로그인 시 백엔드가 portal_link 잔존으로 isPortalLinked:true 를 돌려주는 케이스
-// 대비. /auth/callback 이 이 마커를 보면 강제로 학교 연동 화면으로 보낸다. 30분이면 충분.
-const POST_DELETE_COOKIE = 'cchaksa_post_delete';
-const POST_DELETE_TTL_SECONDS = 30 * 60;
 
 const DeletePage = () => {
   const mutation = useDeleteUserMutation();
@@ -26,13 +20,8 @@ const DeletePage = () => {
 
     try {
       await mutation.mutateAsync();
-      setCookie(POST_DELETE_COOKIE, '1', {
-        maxAge: POST_DELETE_TTL_SECONDS,
-        sameSite: 'lax',
-        path: '/',
-      });
-      // 서버 세션 + 인메모리 토큰 + React Query 캐시 폐기. AuthContext 가 hard navigate 직후
-      // 빈 상태로 마운트되도록 보장.
+      // 서버 세션 + 인메모리 토큰 + React Query 캐시 폐기. BFF 리팩토링 (docs/bff-auth-refactor.md)
+      // 이후 누락된 정리. AuthContext 가 hard navigate 직후 빈 상태로 마운트되도록 보장.
       await clearAuth();
       alert('탈퇴가 완료되었습니다.');
       window.location.replace('/');

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -11,7 +11,7 @@ const STUDENT_PROFILE_PROBE_TIMEOUT_MS = 3_000;
 // 60s 는 임의 — 너무 짧으면 fast path 도중 만료될 위험, 너무 길면 fast path 적중률 떨어짐.
 const FAST_PATH_TOKEN_BUFFER_MS = 60_000;
 
-type ProbeResult = 'ok' | 'unauthorized' | 'error';
+type ProbeResult = 'ok' | 'unauthorized' | 'not-linked' | 'error';
 
 // JWT 의 exp 클레임을 디코드해 토큰 만료 여유를 검사한다. 서명 검증 안 함 —
 // 위조 토큰 차단은 백엔드 책임이고, 여기선 fast-path 자격 판정용으로만 쓴다.
@@ -34,10 +34,12 @@ function hasTokenTimeLeft(accessToken: string, bufferMs: number): boolean {
   }
 }
 
-// 백엔드 `/api/student/profile` 호출 결과를 세 종류로 분류해서 반환한다.
+// 백엔드 `/api/student/profile` 호출 결과를 네 종류로 분류해서 반환한다.
 // - 'ok' (200)            → accessToken 유효 + 사용자가 portal-link 완료된 상태
 // - 'unauthorized' (401)  → accessToken 만료/무효. refresh 가 필요한 신호
-// - 'error' (그 외)       → 백엔드/네트워크 일시 오류. 상태 변경 없이 fallback 으로 처리
+// - 'not-linked' (404)    → accessToken 유효 + 학생 프로필 없음 (S01, STUDENT_NOT_FOUND).
+//                            funnel 로 보내야 할 정상 상태이지 세션 destroy 사유가 아님.
+// - 'error' (그 외)       → 백엔드/네트워크 일시 오류 (5xx, timeout). refresh 시도해 expired-JWT hang 회복.
 //
 // GET 에서 토큰 유효성 검증과 isPortalLinked 승격을 한 번의 백엔드 호출로 수행하고,
 // POST 에서 세션 생성 시 isPortalLinked 초기값을 결정한다.
@@ -53,6 +55,9 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
     });
     if (response.status === 401) {
       return 'unauthorized';
+    }
+    if (response.status === 404) {
+      return 'not-linked';
     }
     if (response.ok) {
       return 'ok';
@@ -74,12 +79,19 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
 // GET /api/session: 클라이언트 하이드레이션 진입점.
 // 1. 쿠키에서 토큰 꺼냄
 // 2. 백엔드 probe 로 유효성 검증
-// 3. probe 가 'ok' 가 아니면(만료·timeout·5xx 등) refresh 시도
-// 4. refresh 실패 시 세션 폐기 + 401 응답 → 클라이언트가 로그아웃 흐름 진입
+// 3. probe 분기:
+//    - 'ok'          → isPortalLinked true 로 승격, 200
+//    - 'not-linked'  → 토큰 유효, 학생 프로필만 없음. refresh 없이 isPortalLinked false 로 200
+//    - 'unauthorized'/'error' → 토큰 문제 가능성. refresh 시도
+// 4. refresh 실패 또는 refresh 후 재-probe 가 'unauthorized' 면 세션 폐기 + 401
 //
 // probe 가 'error' (타임아웃·5xx) 일 때도 refresh 시도하는 이유 — 백엔드가 만료 JWT 처리 중 hang 해서
 // probe 가 401 을 못 받고 timeout 으로 'error' 떨어지는 케이스 관측됨 (Sentry CCHAKSA-56).
 // refresh 엔드포인트는 별도 refreshToken 으로 호출되어 expired-token hang 영향 없음 → 새 토큰 발급 가능.
+//
+// 'not-linked' (404, S01) 는 신규/포털 미연동 사용자의 정상 funnel 상태. 이걸 refresh/destroy 로
+// 처리하면 갓 signin 한 미연동 사용자가 /auth/success → GET /api/session → 401 → '/' 리다이렉트로
+// 튕기는 버그가 발생. /portal-login 으로 보내야 하는 신호일 뿐 세션 무효 신호가 아님.
 //
 // refresh 실패 시 분기 단순화: probe 가 'unauthorized' 든 'error' 든 무조건 세션 폐기.
 // 사용자가 깨진 화면에 갇히는 것보다 로그인 화면으로 보내는 게 명확. 진짜 백엔드 일시 장애여도
@@ -109,6 +121,18 @@ export async function GET() {
 
   let probe = await probeStudentProfile(session.accessToken);
 
+  // 미연동 사용자 (S01) — 토큰은 유효. refresh/destroy 경로 진입 없이 즉시 응답.
+  if (probe === 'not-linked') {
+    if (session.isPortalLinked !== false) {
+      session.isPortalLinked = false;
+    }
+    await session.save();
+    return NextResponse.json({
+      accessToken: session.accessToken,
+      isPortalLinked: false,
+    });
+  }
+
   if (probe !== 'ok') {
     const refreshed = session.refreshToken ? await refreshTokensFromBackend(session.refreshToken) : null;
 
@@ -127,6 +151,18 @@ export async function GET() {
       // refresh 가 발급한 토큰조차 거부 → 백엔드 상태 이상. 세션 폐기.
       await session.destroy();
       return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
+    }
+
+    if (probe === 'not-linked') {
+      // refresh 직후에도 미연동 상태. 새 토큰 유지하면서 false 로 응답.
+      if (session.isPortalLinked !== false) {
+        session.isPortalLinked = false;
+      }
+      await session.save();
+      return NextResponse.json({
+        accessToken: session.accessToken,
+        isPortalLinked: false,
+      });
     }
     // probe === 'error' 면 새 토큰 그대로 유지 — 다음 호출에서 다시 시도.
   }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -31,25 +31,16 @@ export async function GET(request: Request) {
       throw new AuthError('User is missing or malformed.');
     }
 
-    // 탈퇴 직후 재로그인이면 백엔드가 isPortalLinked:true 를 돌려주더라도 (soft-delete 상태에서
-    // portal_link 관계가 잔존하는 케이스) 학교 연동 funnel 을 다시 태우도록 false 로 강제한다.
-    // 마커는 /api/users/delete 성공 직후 클라이언트가 set: src/app/(setting)/delete/page.tsx
-    const postDeleteMarker = await getCookieValue('cchaksa_post_delete');
-    const effectiveIsPortalLinked = postDeleteMarker === '1' ? false : isPortalLinked;
-
     const session = await getSession();
     session.accessToken = accessToken;
     session.refreshToken = refreshToken;
-    session.isPortalLinked = effectiveIsPortalLinked;
+    session.isPortalLinked = isPortalLinked;
     await session.save();
 
     await deleteCookie('state');
     await deleteCookie('nonce');
-    if (postDeleteMarker !== null) {
-      await deleteCookie('cchaksa_post_delete');
-    }
 
-    const nextPath = getRedirectPathForUser({ isPortalLinked: effectiveIsPortalLinked });
+    const nextPath = getRedirectPathForUser({ isPortalLinked });
     const url = new URL('/auth/success', origin);
     url.searchParams.set('redirect', nextPath);
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Context

PR #195 was merged with the **wrong root-cause fix** (marker-cookie override in `/auth/callback`). Production trace afterwards showed `/auth/callback` already routes post-deletion / new-user sign-ins correctly to `/auth/success?redirect=/portal-login`. The bounce-to-home symptom is downstream — in **GET `/api/session`**.

This PR corrects #195 by reverting the marker-cookie branch and applying the real fix.

## 진짜 원인

1. 신규/탈퇴-재가입 사용자는 학생 프로필이 없음 → `/api/student/profile` → **404 (S01, STUDENT_NOT_FOUND)**
2. `probeStudentProfile` 가 404 를 `'error'` 로 분류 (5xx/timeout 과 동일 취급)
3. GET `/api/session` 의 `if (probe !== 'ok')` 분기 → refresh 시도
4. refresh 실패 시 (`!refreshed`) **또는** refresh 후 재-probe 가 `'unauthorized'` 면 → `session.destroy()` + 401
5. `/auth/success` 가 401 받음 → `router.replace('/')` (src/app/auth/success/page.tsx:18-20)
6. 결과: 사용자가 `/portal-login` 대신 `/` 로 튕김

기존 사용자는 fast path (`isPortalLinked:true` + 토큰 시간 남음) 로 probe 자체 우회해서 안 걸렸음. `isPortalLinked:false` 상태로 GET `/api/session` 진입하는 사용자만 함정에 빠짐.

## 변경

### `src/app/api/session/route.ts`
- `ProbeResult` 에 `'not-linked'` 추가
- `probeStudentProfile`: 404 → `'not-linked'` (이전엔 `'error'` 로 흡수)
- GET 핸들러: probe 가 `'not-linked'` 면 refresh/destroy 경로 진입 없이 isPortalLinked:false 로 즉시 200 (초기 probe 와 refresh 후 재-probe 둘 다 처리)
- MPA POST 핸들러: `probe === 'ok'` 비교 그대로 → 'not-linked' 도 자동으로 false 매핑되어 변경 불필요

### `src/app/auth/callback/route.ts`
- #195 의 `cchaksa_post_delete` 마커 쿠키 분기 **revert**. 진단이 틀렸음 — backend signin 응답을 다시 그대로 신뢰

### `src/app/(setting)/delete/page.tsx`
- 마커 쿠키 `setCookie` 제거
- `clearAuth()` + `window.location.replace('/')` **유지** — BFF 리팩토링 (docs/bff-auth-refactor.md) 이후 누락된 세션 정리 (탈퇴 후에도 cchaksa_session 쿠키가 살아남고 in-memory tokenStore 가 stale 토큰 유지). 이 버그와 별개의 hygiene 정정이라 유지

## Test plan
- [ ] 신규 카카오 가입 → `/auth/callback` → `/auth/success` → **`/portal-login` 도달** (이전 dev 에선 `/` 로 튕김)
- [ ] 학교 연동 완료 후 로그인 → `/main` 도달 (fast path 적중)
- [ ] 학교 연동 도중 새로고침 → `/portal-login` 유지 (probe 'not-linked')
- [ ] 토큰 만료 후 자동 새로고침 → refresh 성공 시 정상 동작
- [ ] 탈퇴 → 재로그인 → `/portal-login` 도달 (backend 가 탈퇴 후 재가입 허용한다는 전제)
- [ ] DevTools Network 에서 `/api/student/profile` 404 받았을 때 직후 `/api/auth/refresh` **호출 안 됨** 확인
- [ ] DevTools Application → Cookies 에서 탈퇴 직후 `cchaksa_session` 사라지는지 확인

## 백엔드 fix 와의 관계

이 PR 은 frontend 만으로 닫히는 fix. 백엔드가 탈퇴 후 재가입을 허용하기만 하면 (현재 delete 페이지 카피 "다음 패치 전까지 재가입이 불가능합니다." 가 가리키는 그 패치), 이 변경분이 별도 작업 없이 신규 funnel 을 정상 라우팅함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)