### PR TITLE
fix(auth): re-hydrate AuthContext after portal-link scraping success

### DIFF
--- a/src/app/(funnel)/scraping/page.tsx
+++ b/src/app/(funnel)/scraping/page.tsx
@@ -5,6 +5,7 @@ import { setUser } from '@sentry/nextjs';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { useFunnelContext } from '../contexts';
@@ -17,6 +18,7 @@ const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없습니다. 다시 �
 export default function ScrapingPage() {
   const router = useInternalRouter();
   const { jobId, setStudentInfo } = useFunnelContext();
+  const { hydrate } = useAuth();
 
   const { data: jobStatusData, isTimedOut } = usePortalLinkJobPolling(jobId);
   const jobStatus = jobStatusData?.data?.status;
@@ -43,9 +45,14 @@ export default function ScrapingPage() {
       if (jobId) {
         setUser({ id: jobId });
       }
-      router.push(`${ROUTES.FUNNEL.AGREEMENT}`);
+      // 학교 연동 성공 시점에 AuthContext 와 cchaksa_session 쿠키의 isPortalLinked 를
+      // 백엔드 probe 기반으로 false → true 로 승격. 이게 없으면 /target-score 와 /main 의
+      // ProtectedRoute(requirePortalLinked=true) 가 stale false 를 보고 사용자를 / 로 튕김.
+      void hydrate().finally(() => {
+        router.push(`${ROUTES.FUNNEL.AGREEMENT}`);
+      });
     }
-  }, [summaryData, setStudentInfo, router, jobId]);
+  }, [summaryData, setStudentInfo, router, jobId, hydrate]);
 
   const handleRetry = () => {
     router.push(`${ROUTES.FUNNEL.PORTAL_LOGIN}`);

--- a/src/features/auth/contexts/AuthContext.tsx
+++ b/src/features/auth/contexts/AuthContext.tsx
@@ -15,9 +15,32 @@ interface AuthContextValue {
   isReady: boolean;
   clearAuth: () => Promise<void>;
   refresh: () => Promise<string | null>;
+  // 외부에서 명시적으로 /api/session 재호출이 필요할 때 (e.g. 학교 연동 완료 직후 isPortalLinked
+  // 를 false → true 로 승격해야 하는 시점). 마운트 시 자동 hydrate 와 동일한 로직.
+  hydrate: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
+
+async function fetchSessionState(): Promise<{ accessToken: string | null; isPortalLinked: boolean | null } | null> {
+  try {
+    const response = await fetch('/api/session', { credentials: 'include' });
+    if (!response.ok) {
+      return { accessToken: null, isPortalLinked: null };
+    }
+    const data = (await response.json()) as {
+      accessToken?: string;
+      isPortalLinked?: boolean;
+    };
+    return {
+      accessToken: data.accessToken ?? null,
+      isPortalLinked: typeof data.isPortalLinked === 'boolean' ? data.isPortalLinked : null,
+    };
+  } catch (error) {
+    console.error('[AuthContext] session fetch failed', error);
+    return null;
+  }
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [accessToken, setAccessTokenState] = useState<string | null>(() => getAccessTokenStore());
@@ -41,31 +64,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      try {
-        const response = await fetch('/api/session', { credentials: 'include' });
-        if (cancelled) {return;}
-
-        if (!response.ok) {
-          setAccessTokenStore(null);
-          setIsPortalLinked(null);
-          return;
-        }
-
-        const data = (await response.json()) as {
-          accessToken?: string;
-          isPortalLinked?: boolean;
-        };
-        if (cancelled) {return;}
-
-        setAccessTokenStore(data.accessToken ?? null);
-        setIsPortalLinked(typeof data.isPortalLinked === 'boolean' ? data.isPortalLinked : null);
-      } catch (error) {
-        if (!cancelled) {
-          console.error('[AuthContext] hydrate failed', error);
-        }
-      } finally {
-        if (!cancelled) {setIsReady(true);}
+      const result = await fetchSessionState();
+      if (cancelled) {
+        return;
       }
+      if (result !== null) {
+        setAccessTokenStore(result.accessToken);
+        setIsPortalLinked(result.isPortalLinked);
+      }
+      setIsReady(true);
     })();
 
     return () => {
@@ -85,8 +92,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const refresh = useCallback(() => refreshAccessTokenStore(), []);
 
+  const hydrate = useCallback(async () => {
+    const result = await fetchSessionState();
+    if (result !== null) {
+      setAccessTokenStore(result.accessToken);
+      setIsPortalLinked(result.isPortalLinked);
+    }
+  }, []);
+
   return (
-    <AuthContext.Provider value={{ accessToken, isPortalLinked, isReady, clearAuth, refresh }}>
+    <AuthContext.Provider value={{ accessToken, isPortalLinked, isReady, clearAuth, refresh, hydrate }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## 증상

첫 학교 연동 완료 후 `/main` 으로 자동 진입돼야 하는데 사용자가 `/` (landing) 으로 튕겨서 카카오 로그인부터 다시 하게 됨.

## 원인

`AuthContext` 가 **마운트 시 한 번만** `/api/session` 을 hydrate 함. 신규 사용자 로그인 시점엔 학생 프로필이 아직 없어서 probe → 404/401 → `isPortalLinked: false` 로 메모리에 저장됨. 이후 사용자가 `/portal-login` 에서 연동을 끝내도 (백엔드에 student_profile 생성됨), in-memory `isPortalLinked` 를 갱신할 신호가 없음.

funnel 흐름:
```
/portal-login (연동 submit) → /scraping (job 폴링 성공)
  → /agreement → /complete → /target-score
                                ↓
                  <ProtectedRoute requirePortalLinked={true}>
                  useAuthCheck 가 stale isPortalLinked=false 검사
                                ↓
                  router.replace('/')  ← 사용자 튕김
```

`/target-score` 가 funnel 에서 처음으로 `requirePortalLinked=true` 게이트를 가진 페이지. `portalLinkRedirectTo` 미지정이라 디폴트가 `redirectTo`=`/`.

## fix

### `src/features/auth/contexts/AuthContext.tsx`
- 마운트 시 hydrate 로직을 `fetchSessionState()` 헬퍼로 추출
- `hydrate()` 를 context value 에 노출. 마운트 hydrate 와 동일 로직, 외부 트리거용

### `src/app/(funnel)/scraping/page.tsx`
- `useAuth()` 에서 `hydrate` 가져옴
- 스크래핑 job summary 도착 (= 학교 연동 성공) 시점에 `hydrate()` 호출 → `/api/session` 재요청 → 백엔드 probe 가 200 'ok' 응답 → session cookie 와 AuthContext 양쪽의 `isPortalLinked` 가 `false → true` 로 승격
- 그 다음 `/agreement` 로 push

이러면 `/target-score`, `/main` 게이트 통과.

## Test plan
- [ ] 신규 카카오 가입 → 학교 연동 폼 → 스크래핑 대기 → 동의 → 정보 확인 → 목표 학점 → **`/main` 도달** (이전: `/` 로 튕김)
- [ ] 같은 흐름에서 DevTools Network 탭으로 scraping 페이지에서 `/api/session` 두 번 호출되는지 확인 (마운트 1회 + scraping 성공 후 1회)
- [ ] 두 번째 `/api/session` 응답이 `isPortalLinked: true` 인지 확인
- [ ] 학교 연동 이미 끝난 기존 사용자 로그인 → `/main` 정상 (영향 없음)
- [ ] resync 흐름 (`/resync/scraping` → `/main`) 영향 없는지 확인 — 이미 isPortalLinked=true 사용자라 fast path 적중

## 후속 / 관련

- 백엔드가 spec 외로 미연동 사용자에게 401 주는 케이스는 #197 의 관용 분기가 처리. 이 PR 은 *연동 완료 후 승격* 경로를 다룸 — 둘이 짝
- MPA(webview) 흐름은 `done:portal-link` 브리지로 네이티브가 webview 닫고 dashboard 갱신하는 구조라 SPA `AuthContext` 영향 없음. 변경 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)