### PR TITLE
fix(auth): 보호 페이지 새로고침 시 race 로 인한 A05 노출 차단

### DIFF
--- a/src/app/(main)/academic-detail/layout.tsx
+++ b/src/app/(main)/academic-detail/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { TopNavigation } from '@/components/ui/TopNavigation';
+import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import styles from './layout.module.scss';
 
@@ -8,9 +9,11 @@ export default function GraduationProgressLayout({ children }: { children: React
   const router = useInternalRouter();
 
   return (
-    <div className={styles.container}>
-      <TopNavigation.Preset title="학기별 세부 성적" type="back" onNavigationClick={() => router.back()} />
-      <div className={styles.content}>{children}</div>
-    </div>
+    <ProtectedRoute requirePortalLinked={true}>
+      <div className={styles.container}>
+        <TopNavigation.Preset title="학기별 세부 성적" type="back" onNavigationClick={() => router.back()} />
+        <div className={styles.content}>{children}</div>
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/src/app/(main)/graduation-progress/layout.tsx
+++ b/src/app/(main)/graduation-progress/layout.tsx
@@ -1,12 +1,15 @@
 import GraduationNavigationHeader from '@/features/academic/components/progress/GraduationNavigationHeader';
+import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
 import styles from './layout.module.scss';
 
 export const dynamic = 'force-dynamic';
 export default function GraduationProgressLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className={styles.container}>
-      <GraduationNavigationHeader />
-      <div className={styles.content}>{children}</div>
-    </div>
+    <ProtectedRoute requirePortalLinked={true}>
+      <div className={styles.container}>
+        <GraduationNavigationHeader />
+        <div className={styles.content}>{children}</div>
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/src/app/(main)/graduation-progress/page.tsx
+++ b/src/app/(main)/graduation-progress/page.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
 import GraduationProgressContent from '@/features/academic/components/progress/GraduationProgressContent';
 
 export default function GraduationProgress() {
-  return (
-    <ProtectedRoute requirePortalLinked={true}>
-      <GraduationProgressContent />
-    </ProtectedRoute>
-  );
+  return <GraduationProgressContent />;
 }


### PR DESCRIPTION
## 요약

`/academic-detail`, `/graduation-progress` 등 보호 페이지를 새로고침하면 백엔드가 `A05` ("인증이 필요한 요청입니다.") 를 반환해 사용자에게 인증 에러가 깜빡이거나 그대로 노출되던 race condition 을 차단.

## 원인

`tokenStore.currentToken` 은 모듈 메모리 변수 (`src/features/auth/tokenStore.ts:3`) — 페이지 새로고침 시 `null` 로 리셋. `AuthContext` 가 `GET /api/session` 으로 토큰을 복원하는 동안 (백엔드 probe 포함 ~200ms-3s) 보호 페이지 내부의 `useSuspenseQuery` 가 즉시 발사돼 **Authorization 헤더 없는 요청** 이 백엔드로 나가고 → 401 + A05.

`httpConfig.customFetch` 의 401 auto-refresh 는 원본 요청에 `Authorization` 헤더가 있을 때만 동작하는 가드가 걸려 있어 (`httpConfig.ts:47`), 헤더 없는 race 요청은 refresh 경로조차 못 타고 그대로 에러가 노출됐다.

### 페이지별 진입 경로
- **`/academic-detail`** — `page/layout` 어디에도 `ProtectedRoute` 가 없음. `useAcademicDetail` 내부의 `useSemesterListQuery` 가 즉시 발사 (`useAcademicDetail.ts:26`).
- **`/graduation-progress`** — `page.tsx` 에는 `ProtectedRoute` 가 있었지만, `layout.tsx` 가 `<GraduationNavigationHeader />` 를 children **바깥** 에 두어 보호 범위를 벗어남. 헤더의 `useGraduationNavigation` → `useProfileQuery` 가 먼저 발사.

## 수정

`(mpa)/layout.tsx`, `(main)/main/layout.tsx` 와 동일한 패턴 — **layout 레벨에서 `ProtectedRoute` 적용**.

- `(main)/academic-detail/layout.tsx`: `ProtectedRoute(requirePortalLinked=true)` 래핑 추가
- `(main)/graduation-progress/layout.tsx`: `ProtectedRoute(requirePortalLinked=true)` 래핑 추가
- `(main)/graduation-progress/page.tsx`: layout 으로 이전된 중복 `ProtectedRoute` 제거

## 검증

### 자동
- [x] `yarn type-check` 통과 (exit 0)
- [x] `yarn lint` 0 errors

### 수동 (Test Plan)
- [ ] dv 환경에서 `/academic-detail?year=2025&semester=20` 진입 후 새로고침 ≥3회 → A05 에러 미노출 확인
- [ ] dv 환경에서 `/graduation-progress` 진입 후 새로고침 ≥3회 → A05 에러 미노출 확인
- [ ] 비로그인 상태에서 위 경로 직접 접근 → 홈(`/`) 으로 리다이렉트
- [ ] portal-link 미연동 계정으로 위 경로 진입 → 홈(`/`) 으로 리다이렉트
- [ ] 정상 진입 시 데이터 로딩 + 렌더링 회귀 없음

## 참고
대안으로 고려했던 `tokenStore` 의 hydration promise 도입 (모든 페이지에 자동 적용되는 근본 픽스) 은 비동기 흐름 변경 범위가 커서 후속 리팩토링으로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)