### PR TITLE
feat(analytics): 텍소노미 이벤트 12개 + UserProperties wiring

### DIFF
--- a/src/app/(funnel)/agreement/page.tsx
+++ b/src/app/(funnel)/agreement/page.tsx
@@ -4,10 +4,12 @@ import { useCallback, useState } from 'react';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, useTrackView } from '@/lib/analytics';
 import { AgreementItem, FunnelHeadline, PrivacyPolicySheet } from '../components';
 import styles from './page.module.scss';
 
 const Agreement = () => {
+  useTrackView(EVENTS.UNIV_SYNC_TERM_AGREE_VIEW);
   const router = useInternalRouter();
   const [isAgreed, setIsAgreed] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);

--- a/src/app/(funnel)/complete/page.tsx
+++ b/src/app/(funnel)/complete/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, useTrackView } from '@/lib/analytics';
 import { getSemesterInfo } from '@/lib/utils/semester';
 import { FunnelHeadline } from '../components';
 import { useFunnelContext } from '../contexts';
@@ -19,6 +20,7 @@ function InfoRow({ label, value }: { label: string; value: string }) {
 }
 
 export default function Complete() {
+  useTrackView(EVENTS.UNIV_SYNC_COMPLETE_VIEW);
   const { studentInfo } = useFunnelContext();
   const router = useInternalRouter();
   const handleNext = () => {

--- a/src/app/(funnel)/components/PrivacyPolicySheet/PrivacyPolicySheet.tsx
+++ b/src/app/(funnel)/components/PrivacyPolicySheet/PrivacyPolicySheet.tsx
@@ -1,4 +1,8 @@
+'use client';
+
+import { useEffect } from 'react';
 import { TopNavigation } from '@/components/ui/TopNavigation';
+import { EVENTS, track } from '@/lib/analytics';
 import styles from './PrivacyPolicySheet.module.scss';
 
 interface PrivacyPolicySheetProps {
@@ -7,6 +11,14 @@ interface PrivacyPolicySheetProps {
 }
 
 export default function PrivacyPolicySheet({ isOpen, onClose }: PrivacyPolicySheetProps) {
+  // isOpen 트랜지션 시 1회 발화. unmount → mount 패턴 아님 (조건부 return null)
+  // 이라 useTrackView 사용 불가 — useEffect 로 isOpen 의존성에 직접 묶음.
+  useEffect(() => {
+    if (isOpen) {
+      track(EVENTS.UNIV_SYNC_TERM_AGREE_BOTTOMSHEET_VIEW);
+    }
+  }, [isOpen]);
+
   if (!isOpen) {
     return null;
   }

--- a/src/app/(funnel)/portal-login/components/PortalLoginForm/PortalLoginForm.tsx
+++ b/src/app/(funnel)/portal-login/components/PortalLoginForm/PortalLoginForm.tsx
@@ -5,6 +5,7 @@ import { FixedButton, TextField } from '@/components/ui';
 import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
 import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
+import { EVENTS, track } from '@/lib/analytics';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
 import { useFunnelContext } from '../../../contexts';
@@ -35,6 +36,7 @@ export function PortalLoginForm({ onSuccess, onError }: PortalLoginFormProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    track(EVENTS.UNIV_SYNC_BTN_TAP);
     setErrorMessage('');
 
     const idempotencyKey = generateIdempotencyKey();

--- a/src/app/(funnel)/portal-login/page.tsx
+++ b/src/app/(funnel)/portal-login/page.tsx
@@ -3,11 +3,13 @@
 import { captureException } from '@sentry/nextjs';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, useTrackView } from '@/lib/analytics';
 import { FunnelHeadline, SchoolCard } from '../components';
 import { PortalLoginForm } from './components/PortalLoginForm/PortalLoginForm';
 import styles from './page.module.scss';
 
 export default function PortalLogin() {
+  useTrackView(EVENTS.UNIV_SYNC_LOGIN_VIEW);
   const router = useInternalRouter();
 
   const onSuccess = () => {

--- a/src/app/(funnel)/scraping/page.tsx
+++ b/src/app/(funnel)/scraping/page.tsx
@@ -8,6 +8,7 @@ import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
+import { EVENTS, useTrackView } from '@/lib/analytics';
 import { useFunnelContext } from '../contexts';
 import ErrorScreen from '../components/ErrorScreen/ErrorScreen';
 import LoadingScreen from '../components/LoadingScreen/LoadingScreen';
@@ -16,6 +17,7 @@ import styles from './error.module.scss';
 const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없습니다. 다시 시도해주세요.';
 
 export default function ScrapingPage() {
+  useTrackView(EVENTS.UNIV_SYNC_LOADING_VIEW);
   const router = useInternalRouter();
   const { jobId, setStudentInfo } = useFunnelContext();
   const { hydrate } = useAuth();

--- a/src/app/(funnel)/target-score/page.tsx
+++ b/src/app/(funnel)/target-score/page.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { useSetTargetGpaMutation } from '@/features/student/apis/queries/useSetTargetGpaMutation';
 import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
+import { EVENTS, track } from '@/lib/analytics';
 import { isInWebView, postBridgeMessage } from '@/lib/webview';
 import { FunnelHeadline, ScoreInput } from '../components';
 import styles from './page.module.scss';
@@ -20,8 +21,10 @@ export default function TargetScorePage() {
   const mutation = useSetTargetGpaMutation();
 
   const handleSubmit = async () => {
+    const gpa = parseFloat(score);
+    track(EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP, { gpa });
     try {
-      await mutation.mutateAsync(parseFloat(score));
+      await mutation.mutateAsync(gpa);
       if (isInWebView()) {
         const posted = postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
         if (!posted) {

--- a/src/app/(mpa)/mpa/portal-login/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/page.tsx
@@ -11,6 +11,7 @@ import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
 import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
 import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
 import { isInWebView, postBridgeMessage } from '@/lib/webview';
@@ -24,6 +25,7 @@ import styles from './page.module.scss';
 const BRIDGE_SKIP_PORTAL_LINK = 'skip:portal-link';
 
 export default function MpaPortalLogin() {
+  useTrackView(EVENTS.UNIV_SYNC_LOGIN_VIEW);
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -56,6 +58,7 @@ export default function MpaPortalLogin() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    track(EVENTS.UNIV_SYNC_BTN_TAP);
 
     try {
       setErrorMessage('');

--- a/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
@@ -8,6 +8,7 @@ import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
+import { EVENTS, useTrackView } from '@/lib/analytics';
 import { isInWebView, postBridgeMessage } from '@/lib/webview';
 import ErrorScreen from '@/app/(funnel)/components/ErrorScreen/ErrorScreen';
 import LoadingScreen from '@/app/(funnel)/components/LoadingScreen/LoadingScreen';
@@ -20,6 +21,7 @@ const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
 const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없어요\n다시 로그인해주세요';
 
 export default function MpaPortalLoginScrapingPage() {
+  useTrackView(EVENTS.UNIV_SYNC_LOADING_VIEW);
   const router = useInternalRouter();
 
   const [jobId, setJobId] = useState<string | null>(null);

--- a/src/app/(mpa)/mpa/resync/login/page.tsx
+++ b/src/app/(mpa)/mpa/resync/login/page.tsx
@@ -10,6 +10,7 @@ import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
 import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
+import { EVENTS, track } from '@/lib/analytics';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
 import { FunnelHeadline, SchoolCard } from '@/app/(funnel)/components';
@@ -34,6 +35,7 @@ export default function MpaResyncLogin() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    track(EVENTS.UNIV_RESYNC_BTN_TAP);
 
     try {
       setErrorMessage('');

--- a/src/app/(mpa)/mpa/resync/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/resync/scraping/page.tsx
@@ -7,6 +7,7 @@ import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
 import { isInWebView, postBridgeMessage } from '@/lib/webview';
 import ErrorScreen from '@/app/(funnel)/components/ErrorScreen/ErrorScreen';
 import LoadingScreen from '@/app/(funnel)/components/LoadingScreen/LoadingScreen';
@@ -19,6 +20,7 @@ const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
 const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없어요\n다시 로그인해주세요';
 
 export default function MpaScrapingPage() {
+  useTrackView(EVENTS.UNIV_RESYNC_LOADING_VIEW);
   const router = useInternalRouter();
 
   const [jobId, setJobId] = useState<string | null>(null);
@@ -47,6 +49,7 @@ export default function MpaScrapingPage() {
     // 화면이 표출됨. 폴링은 'succeeded' 시 refetchInterval 에서 자동 정지하므로 state 유지해도 안전.
     sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
     clearRetry();
+    track(EVENTS.UNIV_RESYNC_COMPLETE);
     if (isInWebView()) {
       postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
     } else {

--- a/src/app/resync/login/page.tsx
+++ b/src/app/resync/login/page.tsx
@@ -10,6 +10,7 @@ import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
 import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
+import { EVENTS, track } from '@/lib/analytics';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
 import { FunnelHeadline, SchoolCard } from '../../(funnel)/components';
@@ -34,6 +35,7 @@ export default function PortalLogin() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    track(EVENTS.UNIV_RESYNC_BTN_TAP);
 
     try {
       setErrorMessage('');

--- a/src/app/resync/scraping/page.tsx
+++ b/src/app/resync/scraping/page.tsx
@@ -7,6 +7,7 @@ import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
 import ErrorScreen from '@/app/(funnel)/components/ErrorScreen/ErrorScreen';
 import LoadingScreen from '@/app/(funnel)/components/LoadingScreen/LoadingScreen';
 import styles from './error.module.scss';
@@ -14,6 +15,7 @@ import styles from './error.module.scss';
 const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없습니다. 다시 로그인해주세요.';
 
 export default function ScrapingPage() {
+  useTrackView(EVENTS.UNIV_RESYNC_LOADING_VIEW);
   const router = useInternalRouter();
 
   const [jobId, setJobId] = useState<string | null>(null);
@@ -40,6 +42,7 @@ export default function ScrapingPage() {
       // 폴링은 'succeeded' 시 refetchInterval 에서 자동 정지하므로 state 유지해도 안전.
       sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
       clearRetry();
+      track(EVENTS.UNIV_RESYNC_COMPLETE);
       router.push(ROUTES.MAIN);
     }
   }, [jobStatus, router]);

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -8,6 +8,7 @@ import { Icon } from '@/components/ui';
 import { ROUTES } from '@/constants';
 import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, track } from '@/lib/analytics';
 import styles from './SyncUpdateButton.module.scss';
 
 interface SyncUpdateButtonProps {
@@ -22,6 +23,7 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
     parsedLastSyncedAt && isValid(parsedLastSyncedAt) ? format(parsedLastSyncedAt, 'yy년 M월 d일 HH:mm') : '';
 
   const handleResyncLogin = () => {
+    track(EVENTS.HOME_UNIV_RESYNC_BTN_TAP);
     if (onNavigate) {
       onNavigate();
       return;

--- a/src/lib/analytics/AnalyticsProvider.tsx
+++ b/src/lib/analytics/AnalyticsProvider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { initAnalytics } from '@/lib/analytics/amplitude';
+import { setUserProperties, WEB_VERSION } from '@/lib/analytics/userProperties';
 
 interface AnalyticsProviderProps {
   children: React.ReactNode;
@@ -10,9 +11,13 @@ interface AnalyticsProviderProps {
 // Amplitude SDK 를 클라이언트 진입 직후 1회 초기화. 로그인 전 익명 트래픽도 device_id
 // 단위로 잡히도록 early init. setAnalyticsUser/resetAnalytics 가 내부적으로도 ensureInit
 // 호출하므로 Provider mount 순서에 무관하게 안전.
+//
+// 익명 단계에서도 `sys_web_version` 을 device_id 에 attach 해두면 어떤 빌드 버전이
+// 이벤트를 보낸 건지 분석 단계에서 분리 가능. 로그인 후 user_id 가 채워져도 동일 값 유지.
 export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
   useEffect(() => {
     initAnalytics();
+    setUserProperties({ sys_web_version: WEB_VERSION });
   }, []);
 
   return <>{children}</>;

--- a/src/lib/analytics/amplitude.ts
+++ b/src/lib/analytics/amplitude.ts
@@ -64,3 +64,31 @@ export function resetAnalytics(): void {
   }
   amplitude.reset();
 }
+
+/**
+ * 이벤트 전송 내부 헬퍼. 타입 안전 wrapper 는 `events.ts` 의 `track()` 이며,
+ * 호출부는 항상 그쪽을 사용한다. SDK 직접 호출 차단을 위해 internal 로 분리.
+ */
+export function trackEvent(name: string, properties?: Record<string, unknown>): void {
+  ensureInit();
+  if (typeof window === 'undefined') {
+    return;
+  }
+  amplitude.track(name, properties);
+}
+
+/**
+ * UserProperties 설정 내부 헬퍼. Identify API 로 user-level attach — event properties 와 분리되어
+ * 사용자 단위로 유지된다. 타입 안전 wrapper 는 `userProperties.ts` 의 `setUserProperties()`.
+ */
+export function setUserPropertiesInternal(props: Record<string, string | number | boolean>): void {
+  ensureInit();
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const identify = new amplitude.Identify();
+  for (const [key, value] of Object.entries(props)) {
+    identify.set(key, value);
+  }
+  amplitude.identify(identify);
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,44 @@
+import { trackEvent } from '@/lib/analytics/amplitude';
+
+// 텍소노미 (Notion). 명명 규칙: `<context>_<action>_<noun>`, snake_case.
+// Amplitude Console 의 event 이름과 정확히 일치시킬 것 — 분석 쿼리가 문자열 매칭.
+export const EVENTS = {
+  // 학교 연동 (첫 로그인 후 portal-link 흐름)
+  UNIV_SYNC_LOGIN_VIEW: 'univ_sync_login_view',
+  UNIV_SYNC_BTN_TAP: 'univ_sync_btn_tap',
+  UNIV_SYNC_LOADING_VIEW: 'univ_sync_loading_view',
+  UNIV_SYNC_TERM_AGREE_BOTTOMSHEET_VIEW: 'univ_sync_term_agree_bottomsheet_view',
+  UNIV_SYNC_TERM_AGREE_VIEW: 'univ_sync_term_agree_view',
+  UNIV_SYNC_COMPLETE_VIEW: 'univ_sync_complete_view',
+  UNIV_SYNC_SET_GPA_BTN_TAP: 'univ_sync_set_gpa_btn_tap',
+  // 외국어 학점 인증 — 텍소노미엔 등록되어 있으나 현재 웹에 해당 UI 부재.
+  // 콜사이트 없이 상수만 보존 — 추후 웹에 노출되면 동일 키로 wiring (PM 확인 필요).
+  UNIV_FOREIGN_LANGUAGE_CERTIFICATION_BTN_TAP: 'univ_foreign_language_certification_btn_tap',
+
+  // 학교 재연동 (홈에서 갱신 흐름)
+  HOME_UNIV_RESYNC_BTN_TAP: 'home_univ_resync_btn_tap',
+  UNIV_RESYNC_BTN_TAP: 'univ_resync_btn_tap',
+  UNIV_RESYNC_LOADING_VIEW: 'univ_resync_loading_view',
+  UNIV_RESYNC_COMPLETE: 'univ_resync_complete',
+} as const;
+
+// 페이로드가 필요한 이벤트 — function overload 로 호출 시점에 enforce.
+// 추후 페이로드 있는 이벤트가 추가되면 여기 + 아래 overload 양쪽에 추가.
+export interface SetGpaTapProps {
+  gpa: number;
+}
+
+export type EventName = (typeof EVENTS)[keyof typeof EVENTS];
+
+// 페이로드 없는 이벤트 — name 만 받음.
+type EventNameWithoutProps = Exclude<EventName, typeof EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP>;
+
+// 타입 안전 wrapper — amplitude.track 직접 호출 차단. overload 로 페이로드 강제.
+export function track(name: typeof EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP, properties: SetGpaTapProps): void;
+export function track(name: EventNameWithoutProps): void;
+export function track(name: EventName, properties?: SetGpaTapProps): void {
+  trackEvent(name, properties as Record<string, unknown> | undefined);
+}
+
+// 호출부에서 union 타입 사용 시를 위한 helper — useTrackView 처럼 view 이벤트 전용 hook 에 사용.
+export type ViewEventName = EventNameWithoutProps;

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -1,2 +1,5 @@
-export { initAnalytics, setAnalyticsUser, resetAnalytics } from './amplitude';
+export { initAnalytics, resetAnalytics, setAnalyticsUser } from './amplitude';
 export { AnalyticsProvider } from './AnalyticsProvider';
+export { EVENTS, track, type EventName, type SetGpaTapProps, type ViewEventName } from './events';
+export { useTrackView } from './useTrackView';
+export { setUserProperties, WEB_VERSION } from './userProperties';

--- a/src/lib/analytics/useTrackView.ts
+++ b/src/lib/analytics/useTrackView.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+import { track, type ViewEventName } from '@/lib/analytics/events';
+
+// 뷰 노출 이벤트(`*_view`) 를 컴포넌트 mount 시 1회 발화하는 hook.
+// React 18 StrictMode 의 effect double-invoke 때문에 dev 에서 2회 발화될 수 있으나, prod 빌드는
+// 정상 1회 — Amplitude 의 normal session dedup 도 짧은 간격 중복은 자동 처리.
+//
+// 페이로드가 필요한 이벤트(예: set_gpa)는 이 hook 으로 발화 불가 — `track()` 을 onClick 등에서
+// 직접 호출할 것.
+export function useTrackView(name: ViewEventName): void {
+  useEffect(() => {
+    track(name);
+    // name 변경 시 다시 발화 — 동적으로 페이지 내 다른 view 를 트래킹하는 경우 대응.
+  }, [name]);
+}

--- a/src/lib/analytics/userProperties.ts
+++ b/src/lib/analytics/userProperties.ts
@@ -1,0 +1,24 @@
+import { version as PACKAGE_VERSION } from '../../../package.json';
+import { setUserPropertiesInternal } from '@/lib/analytics/amplitude';
+
+// `sys_web_version` 의 소스. build-time import — process.env.npm_package_version 은
+// Yarn 4/Turbopack 환경에서 누락되는 케이스가 있어 직접 import 가 더 안전.
+// tsconfig 의 resolveJsonModule (Next.js 기본 ON) 에 의존.
+export const WEB_VERSION = PACKAGE_VERSION;
+
+// 텍소노미 (Notion) — UserProperties.
+// `sys_platform` 은 웹/MPA WebView 둘 다 *절대 set 하지 않음* — 네이티브 앱 책임.
+// 크로스 플랫폼 식별은 동일한 analyticsId(user_id) 로 묶이며 device_id 는 분리.
+// `sys_app_version` 도 동일 — 네이티브 책임.
+//
+// TODO(backend): `timetable_count` / `course_count` 는 현재 StudentProfileSchema 에 부재 +
+// 시간표 기능 자체가 native-only. 백엔드가 profile 응답에 노출하거나 별도 endpoint 추가 후
+// `useProfileQuery` queryFn 에서 setUserProperties 호출 추가 (후속 PR).
+interface AllowedUserProperties {
+  sys_web_version?: string;
+}
+
+// 타입 안전 wrapper — 정의되지 않은 키 차단. 텍소노미가 확장되면 AllowedUserProperties 에 추가.
+export function setUserProperties(props: AllowedUserProperties): void {
+  setUserPropertiesInternal(props as Record<string, string | number | boolean>);
+}


### PR DESCRIPTION
## 요약

Notion 텍소노미의 이벤트 12개와 UserProperties (`sys_web_version`) 를 코드에 wiring. PR-A (#203) 의 식별자 인프라 위에 얹는 분석 데이터 수집 트랙 (P2 PR-B).

## Taxonomy 모듈 (`src/lib/analytics/`)

| 파일 | 책임 |
|---|---|
| `events.ts` | `EVENTS` 상수 + function overload 로 페이로드 타입 강제 (`track()` helper) |
| `useTrackView.ts` | `useTrackView(name)` hook — view 이벤트 전용, mount 시 1회 발화 |
| `userProperties.ts` | `setUserProperties()` + `WEB_VERSION` (package.json 빌드타임 import) |
| `amplitude.ts` (확장) | 내부 헬퍼 `trackEvent` / `setUserPropertiesInternal` 추가 — SDK 직접 호출 차단 |

`track()` 은 overload 로 페이로드 강제:
```ts
track(EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP, { gpa: 4.5 }); // ✅ 페이로드 필수
track(EVENTS.UNIV_SYNC_LOGIN_VIEW);                     // ✅ 인자 없음
track(EVENTS.UNIV_SYNC_LOGIN_VIEW, { gpa: 4.5 });       // ❌ 컴파일 에러
track(EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP);                // ❌ 컴파일 에러 (페이로드 누락)
```

## 이벤트 wiring (12개 이벤트, 15개 콜사이트)

### 학교 연동 (funnel + MPA twin)
| 이벤트 | 파일 |
|---|---|
| `univ_sync_login_view` | `(funnel)/portal-login/page.tsx` + `(mpa)/mpa/portal-login/page.tsx` |
| `univ_sync_btn_tap` | `PortalLoginForm.tsx` + MPA 인라인 폼 |
| `univ_sync_loading_view` | `(funnel)/scraping/page.tsx` + `(mpa)/mpa/portal-login/scraping/page.tsx` |
| `univ_sync_term_agree_view` | `(funnel)/agreement/page.tsx` |
| `univ_sync_term_agree_bottomsheet_view` | `PrivacyPolicySheet.tsx` — conditional return null 패턴이라 `useTrackView` 불가, `useEffect+isOpen` 의존성으로 처리 |
| `univ_sync_complete_view` | `(funnel)/complete/page.tsx` |
| `univ_sync_set_gpa_btn_tap` | `(funnel)/target-score/page.tsx`, `{ gpa: parseFloat(score) }` 페이로드 |

### 학교 재연동
| 이벤트 | 파일 |
|---|---|
| `home_univ_resync_btn_tap` | `SyncUpdateButton.tsx` |
| `univ_resync_btn_tap` | `resync/login/page.tsx` + `(mpa)/mpa/resync/login/page.tsx` |
| `univ_resync_loading_view` | `resync/scraping/page.tsx` + `(mpa)/mpa/resync/scraping/page.tsx` |
| `univ_resync_complete` | succeeded effect 안, `router.push` / `postBridgeMessage` 직전 |

## UserProperties

- `sys_web_version` — `AnalyticsProvider` mount 시 `setUserProperties` 호출. 익명 단계에도 attach.
  값은 `package.json` 의 version (build-time import). 로그인 후 user_id 채워져도 동일 값 유지.
- `sys_platform` / `sys_app_version` — **웹 절대 set 안 함**. 네이티브 책임. 크로스 플랫폼 식별은 공통 `analyticsId`(user_id) 로 묶임.

## 확인 필요 / 추후 작업

### PM 확인 — 외국어 학점 인증 이벤트
`univ_foreign_language_certification_btn_tap` — **웹 UI 부재**, 텍소노미 일관성을 위해 `EVENTS` 상수만 보존 + 콜사이트 없음. PM 확인 필요:
- [ ] 웹 노출 예정인가 (그러면 어디?)
- [ ] 네이티브 전용인가 (그러면 웹 상수는 dead code — 제거 vs 유지 선택)

### Backend 확인 — `timetable_count` / `course_count`
`StudentProfileSchema` 에 필드 부재 + 시간표 기능 자체가 native-only. 백엔드가 profile 응답에 노출하면 `useProfileQuery` queryFn 에서 `setUserProperties` 호출 추가 (후속 PR).

## 검증

### 자동
- [x] `yarn type-check` 통과 — function overload 가 페이로드 누락/오타를 컴파일 단계에서 차단
- [x] `yarn lint` 0 errors (기존 warning 18개)

### 수동 (Test Plan)
- [ ] dv 환경에서 단일 user_id 로 funnel 전체 수행 (portal-login → submit → scraping → agreement → complete → target-score) → Amplitude debugger 에서 7개 이벤트 시퀀스 확인
- [ ] `univ_sync_set_gpa_btn_tap` 의 `gpa` 프로퍼티가 입력값과 일치
- [ ] resync path: home → resync btn → loading → complete 4개 이벤트 확인
- [ ] User Lookup 에서 `user_properties.sys_web_version` = `package.json` 의 version (현재 `0.1.0`)
- [ ] `user_properties.sys_platform` 이 **부재** (웹은 set 안 함) 확인

## 의존성

- PR-A (#203, 머지됨) — 식별자 wiring 인프라
- 운영팀: Amplitude prod 키 발급 (TODO — 미설정 시 코드는 silent skip 으로 안전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 사용자 상호작용 및 페이지 방문에 대한 분석 추적을 추가했습니다. 학교 연동, 로그인, 폼 제출 등 주요 사용자 행동이 추적되도록 개선했습니다.
  * 웹 애플리케이션 버전 정보를 사용자 속성에 포함시키도록 구성했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gyumong/chukchuk-haksa/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->