### PR TITLE
fix(portal-link): 래퍼 응답 언랩 누락으로 인한 학교 연동 요청 실패 회귀 수정

### DIFF
--- a/src/features/portal-link/services/__tests__/portalLinkService.test.ts
+++ b/src/features/portal-link/services/__tests__/portalLinkService.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { unwrapData } from '../portalLinkService';
+
+describe('unwrapData', () => {
+  it('SpringBoot 래퍼({ success, data, message }) 응답에서 data 를 추출한다', () => {
+    // 실제 백엔드(202 Accepted)가 내려주는 래퍼 형태
+    const wrapped = {
+      success: true,
+      data: {
+        job_id: '528f6966-d4ca-45ac-8fd6-c41f9f014bb8',
+        polling_endpoint: '/portal/link/jobs/528f6966-d4ca-45ac-8fd6-c41f9f014bb8',
+        status: 'accepted',
+      },
+      message: '요청 성공',
+    };
+
+    expect(unwrapData(wrapped)).toEqual({
+      job_id: '528f6966-d4ca-45ac-8fd6-c41f9f014bb8',
+      polling_endpoint: '/portal/link/jobs/528f6966-d4ca-45ac-8fd6-c41f9f014bb8',
+      status: 'accepted',
+    });
+  });
+
+  it('래퍼의 job_id 를 flat 으로 노출해 호출부가 .job_id 로 읽을 수 있다', () => {
+    const wrapped = { success: true, data: { job_id: 'abc' }, message: '요청 성공' };
+    expect(unwrapData(wrapped).job_id).toBe('abc');
+  });
+
+  it('이미 flat 한 응답은 그대로 반환한다 (백엔드가 추후 flat 전환해도 동작)', () => {
+    const flat = { job_id: 'abc', status: 'accepted' };
+    expect(unwrapData(flat)).toBe(flat);
+  });
+
+  it('success/data 키가 없는 객체는 래퍼로 오인하지 않는다', () => {
+    const jobStatus = { status: 'succeeded', error_code: null };
+    expect(unwrapData(jobStatus)).toBe(jobStatus);
+  });
+
+  it('null 을 안전하게 통과시킨다', () => {
+    expect(unwrapData(null as unknown as { status: string })).toBeNull();
+  });
+});

--- a/src/features/portal-link/services/portalLinkService.ts
+++ b/src/features/portal-link/services/portalLinkService.ts
@@ -12,19 +12,49 @@ interface SubmitPortalLinkParams {
   idempotencyKey: string;
 }
 
+type MaybeWrapped<T> = T | { success: boolean; data: T; message?: string };
+
+/**
+ * 백엔드 포털 연동 엔드포인트는 SpringBoot 공통 래퍼(`{ success, data, message }`)로 응답한다.
+ * 그러나 `yarn api:update` 로 재생성된 swagger 타입(`AcceptedResponse` 등)은 래퍼 안쪽
+ * payload 모양만 기술하고, 공용 `ApiResponseHandler` 는 래퍼를 언랩하지 않는다. 따라서
+ * 런타임 응답이 래퍼면 `data` 를 추출해 flat 으로 정규화한다 (이미 flat 이면 그대로 둔다).
+ *
+ * 이 언랩이 없으면 호출부가 읽는 `.job_id` / `.status` 가 `undefined` 가 되어 202 정상 응답을
+ * "연동 요청에 실패" 로 오판한다 — PR #202 가 호출부를 `.data.X → .X` 로 평탄화하면서 이
+ * 언랩을 누락해 발생한 `/resync/login`·`/portal-login` 회귀를 복구한다. 백엔드가 추후 flat
+ * 응답으로 전환해도 그대로 동작한다.
+ */
+export function unwrapData<T>(response: MaybeWrapped<T>): T {
+  if (response !== null && typeof response === 'object' && 'success' in response && 'data' in response) {
+    return (response as { data: T }).data;
+  }
+  return response as T;
+}
+
 export async function submitPortalLink({ username, password, idempotencyKey }: SubmitPortalLinkParams) {
-  return ApiResponseHandler.handleAsyncResponse<AcceptedResponse>(
+  const response = await ApiResponseHandler.handleAsyncResponse<MaybeWrapped<AcceptedResponse>>(
     portalLinkApi.createPortalLinkJob(
       { portal_type: 'suwon', username, password },
       { headers: { 'Idempotency-Key': idempotencyKey } }
     )
   );
+
+  return unwrapData(response);
 }
 
 export async function getJobStatus(jobId: string) {
-  return ApiResponseHandler.handleAsyncResponse<JobStatusResponse>(portalJobQueryApi.getJobStatus(jobId));
+  const response = await ApiResponseHandler.handleAsyncResponse<MaybeWrapped<JobStatusResponse>>(
+    portalJobQueryApi.getJobStatus(jobId)
+  );
+
+  return unwrapData(response);
 }
 
 export async function getJobSummary(jobId: string) {
-  return ApiResponseHandler.handleAsyncResponse<JobSummaryResponse>(portalJobQueryApi.getJobSummary(jobId));
+  const response = await ApiResponseHandler.handleAsyncResponse<MaybeWrapped<JobSummaryResponse>>(
+    portalJobQueryApi.getJobSummary(jobId)
+  );
+
+  return unwrapData(response);
 }


### PR DESCRIPTION
## 요약

`/resync/login`(및 `/portal-login` 첫 연동)에서 학교 연동 요청 시 백엔드가 **202 Accepted + 정상 응답**을 주는데도 **"연동 요청에 실패했습니다. 다시 시도해주세요."** 가 노출되던 회귀를 수정합니다.

재현된 백엔드 응답:
```json
{ "success": true, "data": { "job_id": "528f...", "polling_endpoint": "/portal/link/jobs/528f...", "status": "accepted" }, "message": "요청 성공" }
```

## 원인

PR #202가 `yarn api:update` 부수효과로 portal-link 호출부를 `.data.X → .X`(flat)로 평탄화하고 생성 타입(`AcceptedResponse` 등)도 flat으로 바뀌었으나, **실제 백엔드는 여전히 SpringBoot 공통 래퍼 `{ success, data, message }`로 응답**합니다.

- 공용 `ApiResponseHandler.handleResponse`는 `response.json()`을 **언랩 없이 그대로 반환**
- PR #202 이전 `portalLinkService`는 `SuccessResponse*`(래퍼) 타입으로 받아 `response`를 반환 → 호출부가 `.data.job_id`로 읽어 동작
- PR #202 이후 service가 flat 타입으로 받아 반환만 하므로, 런타임 응답은 여전히 래퍼인데 호출부는 `.job_id`(flat)를 읽음 → `undefined` → 실패 오판

폴링(`getJobStatus`)·요약(`getJobSummary`)도 동일 원인으로 깨집니다.

## 수정

`portalLinkService`의 `submit`/`status`/`summary` 세 함수에 `unwrapData` 정규화를 적용했습니다.

- 래퍼(`{ success, data }`)면 `data`를 추출, 이미 flat이면 그대로 반환 → **백엔드가 추후 flat으로 전환해도 안전**
- 공용 `ApiResponseHandler`는 **미변경** (다른 도메인 영향 차단)
- 한 곳 수정으로 `/resync` · `/portal-login` 첫 연동 · 폴링 · 요약 · MPA twin 전부 복구

## 영향 범위 참고

현재 `main`과 `dev` 트리가 동일하여 **프로덕션에도 동일 버그가 존재**합니다. dev 머지 후 main 승격이 필요합니다.

## 검증

- [x] `yarn type-check` 통과
- [x] `yarn lint` 0 errors
- [x] 신규 유닛 테스트 `unwrapData` 5건 통과 (실제 202 페이로드 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
