### PR TITLE
feat(mpa): WebView 네이티브 브릿지 연동 (redirectToHome/withdraw/Topbar) + 크래시·세션 race 핫픽스

### DIFF
--- a/src/app/(mpa)/layout.tsx
+++ b/src/app/(mpa)/layout.tsx
@@ -1,13 +1,40 @@
 'use client';
 
-import type { PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { TopNavigation } from '@/components/ui/TopNavigation';
+import { ROUTES } from '@/constants/routes';
+import GraduationNavigationHeader from '@/features/academic/components/progress/GraduationNavigationHeader';
 import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
 import styles from './layout.module.scss';
 
 export default function MpaLayout({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+  const router = useInternalRouter();
+
+  // mpa/home 만 Topbar 없음(네이티브 홈 헤더 사용). 그 외 페이지는 대응되는 웹 화면의 Topbar 를
+  // 그대로 따른다. 뒤로가기는 useInternalRouter.back() 으로 — webview 에선 navigateBack 브릿지가
+  // 함께 송출되고 웹 자체 뒤로가기도 수행된다. 펀널·로딩 페이지(portal-login·scraping·resync/scraping)는
+  // 웹과 동일하게 Topbar 없음.
+  const renderTopbar = (): ReactNode => {
+    switch (pathname) {
+      case ROUTES.MPA.GRADUATION_PROGRESS:
+        // 웹 졸업요건과 동일한 동적 제목("{학번} {학부} 졸업요건") + 뒤로가기.
+        return <GraduationNavigationHeader />;
+      case ROUTES.MPA.ME:
+        return <TopNavigation.Preset title="설정" type="back" onNavigationClick={() => router.back()} />;
+      case ROUTES.MPA.RESYNC_LOGIN:
+        return <TopNavigation.Preset title="" type="back" onNavigationClick={() => router.back()} />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <ProtectedRoute>
       <div className={styles.container}>
+        {renderTopbar()}
         <div className={styles.content}>{children}</div>
       </div>
     </ProtectedRoute>

--- a/src/app/(mpa)/mpa/me/page.tsx
+++ b/src/app/(mpa)/mpa/me/page.tsx
@@ -2,8 +2,7 @@
 
 import { Icon } from '@/components/ui';
 import { Menu } from '@/components/ui/Menu';
-import { ROUTES } from '@/constants/routes';
-import { navigateNative } from '@/lib/webview';
+import { withdraw } from '@/lib/webview';
 
 const MpaMePage = () => {
   const menuItems = [
@@ -11,7 +10,7 @@ const MpaMePage = () => {
       label: '탈퇴하기',
       color: '#FF5751',
       icon: <Icon name="arrow-right" size={24} />,
-      onClick: () => navigateNative(ROUTES.MPA.DELETE),
+      onClick: () => withdraw(),
     },
   ];
 

--- a/src/app/(mpa)/mpa/portal-login/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/page.tsx
@@ -13,30 +13,25 @@ import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping
 import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
-import { isInWebView, postBridgeMessage } from '@/lib/webview';
+import { isInWebView, redirectToHome } from '@/lib/webview';
 import { FunnelHeadline, SchoolCard } from '@/app/(funnel)/components';
 import sharedStyles from '@/app/resync/login/page.module.scss';
 import styles from './page.module.scss';
-
-// 신입생·편입생 등 즉시 학교 인증이 불가한 사용자가 "확인" 으로 학교 연동 건너뛰기 선택 시
-// 네이티브에 송출. 네이티브가 webview dismiss + 시간표 만들기 화면으로 전환.
-// 프로토콜: docs/mpa-school-link-handoff.md M3.
-const BRIDGE_SKIP_PORTAL_LINK = 'skip:portal-link';
 
 export default function MpaPortalLogin() {
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [isSkipDialogOpen, setIsSkipDialogOpen] = useState<boolean>(false);
+  const [isUnavailableDialogOpen, setIsUnavailableDialogOpen] = useState<boolean>(false);
   const router = useInternalRouter();
   const linkMutation = usePortalLinkMutation();
 
-  const handleSkipConfirm = () => {
-    setIsSkipDialogOpen(false);
-    // 네이티브에 학교 연동 건너뛰기 의사 전달. webview 환경 아니면 noop —
+  const handleUnavailableConfirm = () => {
+    setIsUnavailableDialogOpen(false);
+    // 학교 인증이 불가한 사용자가 "확인" 시 네이티브 앱 홈으로 이동 위임. webview 환경 아니면 noop —
     // (mpa) 라우트는 webview 전용이라 사실상 도달 안 함, 안전망 차원.
     if (isInWebView()) {
-      const posted = postBridgeMessage(BRIDGE_SKIP_PORTAL_LINK);
+      const posted = redirectToHome();
       if (!posted) {
         // bridge 송출 실패 시 사용자가 다이얼로그 닫힌 채 무반응 상태에 갇히지 않도록 인라인 에러 노출.
         setErrorMessage('요청 처리에 실패했어요. 다시 시도해주세요.');
@@ -116,7 +111,7 @@ export default function MpaPortalLogin() {
           </div>
         )}
 
-        <button type="button" className={styles.skipLink} onClick={() => setIsSkipDialogOpen(true)}>
+        <button type="button" className={styles.skipLink} onClick={() => setIsUnavailableDialogOpen(true)}>
           즉시 학교 연동이 불가하신가요?
           <br />
           (ex. 신입생, 편입생)
@@ -132,10 +127,10 @@ export default function MpaPortalLogin() {
       </form>
 
       <ConfirmDialog
-        isOpen={isSkipDialogOpen}
+        isOpen={isUnavailableDialogOpen}
         message={`학교 연동없이 이용시\n'시간표 만들기'만 이용 가능합니다.`}
-        onConfirm={handleSkipConfirm}
-        onClose={() => setIsSkipDialogOpen(false)}
+        onConfirm={handleUnavailableConfirm}
+        onClose={() => setIsUnavailableDialogOpen(false)}
       />
     </div>
   );

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -212,7 +212,8 @@ interface SessionExchangeBody {
 // 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
 // 시퀀스: docs/mpa-school-link-handoff.md
 // isPortalLinked 는 요청 바디에서 받지 않고 백엔드 probe 결과로 결정 — 클라이언트 임의 값으로
-// 세션 승격되는 경로 차단. probe 가 일시 실패(`'error'`)면 false 로 저장되고, 다음 GET 에서 재시도.
+// 세션 승격되는 경로 차단. probe 가 만료(401)/일시오류(timeout·5xx)면 refreshToken 으로 재발급 후
+// 재-probe 한다 (GET 과 동일) — cold start 직후 연동 사용자가 미연동으로 오판되는 것을 막는다.
 // TODO(backend): 토큰 진위 검증 엔드포인트가 추가되면 sealData 직전 호출해 위조 토큰 차단.
 export async function POST(request: Request) {
   let body: SessionExchangeBody;
@@ -233,15 +234,36 @@ export async function POST(request: Request) {
 
   // probe 와 analyticsId fetch 는 서로 독립 — 병렬로 latency 단축.
   // MPA WebView 첫 진입 시 식별자를 즉시 채워, 다음 GET 부터 분석 wire-up 정상 동작.
-  const [probe, analyticsId] = await Promise.all([
+  let activeAccessToken = accessToken;
+  let activeRefreshToken = refreshToken;
+  let [probe, analyticsId] = await Promise.all([
     probeStudentProfile(accessToken),
     fetchAnalyticsIdFromBackend(accessToken),
   ]);
+
+  // cold start 등으로 native 가 보유한 accessToken 이 만료(401)거나 백엔드 일시오류(timeout·5xx)면,
+  // 단일 probe 결과로 isPortalLinked=false 를 굳히지 않는다 — refreshToken 으로 재발급 후 재-probe.
+  // 이게 없으면 이미 연동된 사용자가 cold start 직후 미연동으로 오판되고, 그 false 가 세션에 저장돼
+  // 이후 GET 의 'unlinked 자체 선언' 분기(아래 GET 주석 참조)가 refresh 를 건너뛰어 false 가 고착,
+  // 네이티브가 "학교 연동을 하시겠습니까?" 프롬프트를 잘못 띄운다. (GET 의 refresh+re-probe 와 동일 원리.)
+  // 'not-linked'(404)는 정상 미연동이라 refresh 하지 않는다. refresh 실패 시엔 기존 동작 유지(다음 진입 재시도).
+  if (probe !== 'ok' && probe !== 'not-linked') {
+    const refreshed = await refreshTokensFromBackend(refreshToken);
+    if (refreshed) {
+      activeAccessToken = refreshed.accessToken;
+      activeRefreshToken = refreshed.refreshToken;
+      [probe, analyticsId] = await Promise.all([
+        probeStudentProfile(activeAccessToken),
+        fetchAnalyticsIdFromBackend(activeAccessToken),
+      ]);
+    }
+  }
+
   const isPortalLinked = probe === 'ok';
 
   const session = await getSession();
-  session.accessToken = accessToken;
-  session.refreshToken = refreshToken;
+  session.accessToken = activeAccessToken;
+  session.refreshToken = activeRefreshToken;
   session.isPortalLinked = isPortalLinked;
   // 명시적 설정/해제 — 동일 쿠키에서 다른 사용자로 재익스체인지될 경우 이전 analyticsId leak 방지.
   if (analyticsId) {

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -246,7 +246,8 @@ export async function POST(request: Request) {
   // 이게 없으면 이미 연동된 사용자가 cold start 직후 미연동으로 오판되고, 그 false 가 세션에 저장돼
   // 이후 GET 의 'unlinked 자체 선언' 분기(아래 GET 주석 참조)가 refresh 를 건너뛰어 false 가 고착,
   // 네이티브가 "학교 연동을 하시겠습니까?" 프롬프트를 잘못 띄운다. (GET 의 refresh+re-probe 와 동일 원리.)
-  // 'not-linked'(404)는 정상 미연동이라 refresh 하지 않는다. refresh 실패 시엔 기존 동작 유지(다음 진입 재시도).
+  // 'not-linked'(404)는 정상 미연동이라 refresh 하지 않는다. refresh 실패/재-probe 불확정이면
+  // 아래에서 isPortalLinked 를 저장하지 않고 unset 으로 남겨 다음 GET 이 정상 refresh 로 복구한다.
   if (probe !== 'ok' && probe !== 'not-linked') {
     const refreshed = await refreshTokensFromBackend(refreshToken);
     if (refreshed) {
@@ -259,12 +260,20 @@ export async function POST(request: Request) {
     }
   }
 
-  const isPortalLinked = probe === 'ok';
+  // probe 가 확정적일 때만 저장한다. 'ok'→true, 'not-linked'→false. 'error'/'unauthorized'(refresh
+  // 후에도 불확정)는 undefined 로 두고 session 에 굳히지 않는다 — false 를 저장하면 GET 의 'unlinked
+  // 자체 선언' 분기가 refresh 를 건너뛰어 만료 토큰+false 가 고착되므로, unset 으로 남겨 다음 GET 이
+  // 정상 refresh 경로를 타게 한다.
+  const isPortalLinked = probe === 'ok' ? true : probe === 'not-linked' ? false : undefined;
 
   const session = await getSession();
   session.accessToken = activeAccessToken;
   session.refreshToken = activeRefreshToken;
-  session.isPortalLinked = isPortalLinked;
+  if (isPortalLinked === undefined) {
+    delete session.isPortalLinked;
+  } else {
+    session.isPortalLinked = isPortalLinked;
+  }
   // 명시적 설정/해제 — 동일 쿠키에서 다른 사용자로 재익스체인지될 경우 이전 analyticsId leak 방지.
   if (analyticsId) {
     session.analyticsId = analyticsId;
@@ -273,5 +282,5 @@ export async function POST(request: Request) {
   }
   await session.save();
 
-  return NextResponse.json({ ok: true, isPortalLinked });
+  return NextResponse.json({ ok: true, isPortalLinked: isPortalLinked ?? false });
 }

--- a/src/features/academic/apis/service.ts
+++ b/src/features/academic/apis/service.ts
@@ -16,7 +16,20 @@ export async function fetchAcademicRecord(year: number, semester: number): Promi
   const response = await ApiResponseHandler.handleAsyncResponse<AcademicRecordApiResponse>(
     academicRecordApi.getAcademicRecord({ year, semester })
   );
-  return response.data;
+
+  // 생성된 타입은 courses.major/liberal/etc 를 필수 배열로 선언하지만, 백엔드가 일부 학기에서
+  // 'etc'(기타, PR #202 신규 필드) 등을 생략해 내려준다(런타임 undefined). 이 경우 page 의
+  // `courses.etc.length` 접근이 "Cannot read properties of undefined (reading 'length')" 로
+  // 터진다. 타입 계약(항상 배열)에 맞춰 누락 필드를 빈 배열로 정규화한다.
+  const data = response.data;
+  return {
+    ...data,
+    courses: {
+      major: data.courses?.major ?? [],
+      liberal: data.courses?.liberal ?? [],
+      etc: data.courses?.etc ?? [],
+    },
+  };
 }
 
 /**

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -73,3 +73,10 @@ export const navigateNative = (url: string): boolean => {
 export const navigateBack = (): boolean => {
   return postBridgeMessage('navigateBack');
 };
+
+// 웹에서 홈으로 리다이렉트하는 지점을, 웹뷰에선 네이티브 앱 홈 화면으로의 이동으로 위임한다.
+// (웹은 router.push(home), 웹뷰는 이 이벤트만 송출하고 자체 라우팅은 하지 않음.)
+// 학교 인증 '완료' 신호인 done:portal-link 와는 별개 — 이쪽은 단순 홈 이동 의도다.
+export const redirectToHome = (): boolean => {
+  return postBridgeMessage('redirectToHome');
+};

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -80,3 +80,9 @@ export const navigateBack = (): boolean => {
 export const redirectToHome = (): boolean => {
   return postBridgeMessage('redirectToHome');
 };
+
+// /mpa/me 의 '탈퇴하기' → 네이티브에 계정 탈퇴 플로우 진입을 위임한다. 네이티브가 탈퇴 확인/처리
+// 화면을 자체적으로 띄운다 (웹뷰는 라우팅하지 않음). 기존 navigate:/mpa/delete dispatch 를 대체.
+export const withdraw = (): boolean => {
+  return postBridgeMessage('withdraw');
+};

--- a/src/lib/webview/index.ts
+++ b/src/lib/webview/index.ts
@@ -1,1 +1,1 @@
-export { isInWebView, postBridgeMessage, navigateNative, navigateBack } from './bridge';
+export { isInWebView, postBridgeMessage, navigateNative, navigateBack, redirectToHome } from './bridge';

--- a/src/lib/webview/index.ts
+++ b/src/lib/webview/index.ts
@@ -1,1 +1,1 @@
-export { isInWebView, postBridgeMessage, navigateNative, navigateBack, redirectToHome } from './bridge';
+export { isInWebView, postBridgeMessage, navigateNative, navigateBack, redirectToHome, withdraw } from './bridge';


### PR DESCRIPTION
## 요약

MPA(모바일 WebView) 네이티브 브릿지 연동을 보강하고, 진행 중 발견된 프로덕션 크래시 2건을 함께 수정합니다.

## 변경 내용

### feat — MPA WebView 브릿지/네비게이션
- `redirectToHome()` 브릿지 이벤트 추가 (웹은 `router.push(home)`, 웹뷰는 이벤트만 송출)
- `/mpa/portal-login` "학교 연동 불가" 팝업 확인 → `skip:portal-link` 대신 `redirectToHome` (홈 이동으로 일원화, 버튼/문구/위치 유지)
- `/mpa/me` 탈퇴하기 → `navigate:/mpa/delete` 대신 전용 `withdraw` 이벤트
- `(mpa)` 레이아웃: `mpa/home` 제외 페이지에 대응 웹 화면과 동일한 Topbar (graduation=동적 "{학번} {학부} 졸업요건", me="설정", resync/login=제목없음; 펀널·로딩 페이지는 웹과 동일하게 없음). 뒤로가기는 `useInternalRouter.back()` 경유 → 웹뷰에서 `navigateBack` 자동 송출

### fix — 크래시/회귀
- **academic-detail 크래시**: `courses.etc`(PR #202 신규 필드)를 백엔드가 일부 학기(예: 2025-2학기)에서 생략 → `courses.etc.length` 접근 시 "Cannot read properties of undefined (reading 'length')" 크래시. `fetchAcademicRecord`에서 `courses.major/liberal/etc`를 `[]`로 정규화.
- **cold-start 미연동 오판**: `POST /api/session`이 단일 probe로 만료 토큰에 `isPortalLinked=false`를 굳혀, 이미 연동된 사용자에게 네이티브가 "학교 연동을 하시겠습니까?"를 띄우던 race. GET과 동일하게 refresh+re-probe 추가.

## 🔌 네이티브 계약 변경 (필독)
- **신규 처리 필요**: `redirectToHome`, `withdraw`
- **제거/대체**: `skip:portal-link` 더 이상 송출 안 함 / `navigate:/mpa/delete` → `withdraw`
- 첫 회원가입 학교연동 웹뷰 URL = `/mpa/portal-login`

## ⚠️ 프로덕션 영향
위 두 fix는 현재 `main`(프로덕션)에도 존재하는 버그입니다. dev 머지 후 main 승격 권장 — 특히 academic-detail 크래시.

## 검증
- [x] `yarn type-check` 0
- [x] `yarn lint` 0
- [x] 테스트 33/33 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 학사 기록 데이터 조회 시 누락 필드로 인한 오류 방지

* **Improvements**
  * 세션 토큰 자동 갱신 및 재확인 로직 개선
  * 계정 탈퇴 프로세스 개선
  * 학교 연동 건너뛰기 처리 최적화
  * 앱 내 네비게이션 구조 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gyumong/chukchuk-haksa/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->