### PR TITLE
fix(auth): 홈 복귀 시 isPortalLinked 갱신 (visibility 재하이드레이션)

### DIFF
--- a/src/features/auth/contexts/AuthContext.tsx
+++ b/src/features/auth/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { captureException } from '@sentry/nextjs';
 import { queryClient } from '@/shared/api/configs/queryClient';
 import { resetAnalytics, setAnalyticsUser } from '@/lib/analytics';
 import {
@@ -48,7 +49,9 @@ async function fetchSessionState(): Promise<SessionState | null> {
       analyticsId: data.analyticsId ?? null,
     };
   } catch (error) {
+    // 세션 재호출 실패도 telemetry 로 추적 (CLAUDE.md: Sentry 에러 트래킹). 로컬 디버그용 console 유지.
     console.error('[AuthContext] session fetch failed', error);
+    captureException(error, { tags: { scope: 'auth', action: 'fetchSessionState' } });
     return null;
   }
 }

--- a/src/features/dashboard/hooks/useRefreshProfileOnVisible.ts
+++ b/src/features/dashboard/hooks/useRefreshProfileOnVisible.ts
@@ -2,18 +2,24 @@
 
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { dashboardQueryKeys } from '@/features/dashboard/apis/queryKey';
 
 // 네이티브 resync 후 WebView 복귀가 React 라이프사이클을 거치지 않을 수 있어 visibilitychange 로 보강.
 // 배경/대안 비교: docs/profile-staleness-on-resync.md
 export function useRefreshProfileOnVisible() {
   const queryClient = useQueryClient();
+  const { hydrate } = useAuth();
 
   useEffect(() => {
     const onVisibilityChange = () => {
       if (document.visibilityState !== 'visible') {
         return;
       }
+      // 세션(isPortalLinked 등)도 함께 재하이드레이션한다. profile 쿼리만 invalidate 하면
+      // AuthContext 의 isPortalLinked 가 옛 값으로 남아, 네이티브 홈 복귀(webview 미reload) 시
+      // 학교 연동 상태가 갱신되지 않는다. hydrate() 는 GET /api/session 을 다시 호출한다.
+      void hydrate();
       queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.profile });
     };
 
@@ -21,5 +27,5 @@ export function useRefreshProfileOnVisible() {
     return () => {
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, [queryClient]);
+  }, [queryClient, hydrate]);
 }


### PR DESCRIPTION
## 요약
네이티브 홈 버튼으로 `/mpa/home`에 복귀해도 `isPortalLinked`(학교 연동 상태)가 갱신되지 않던 문제를 수정합니다.

## 원인
`/mpa/home`·`/main`이 쓰는 `useRefreshProfileOnVisible`이 `visibilitychange` 시 **React-Query의 profile 쿼리만 invalidate**하고, **`AuthContext.hydrate()`(=`GET /api/session` 재호출)는 하지 않았습니다.** 그래서 webview가 reload 없이 다시 보일 때 AuthContext의 `isPortalLinked`가 옛 값 그대로 남았습니다.

## 변경
- `useRefreshProfileOnVisible`: `visible` 전환 시 `hydrate()`도 호출해 세션(isPortalLinked 등)을 함께 재하이드레이션. (`hydrate`는 AuthContext의 안정적 useCallback)

## 검증
- [x] `yarn type-check` 0
- [x] `yarn lint` 0
- [x] test 33/33

## 참고 (별건)
홈의 `NETWORK_ERROR 500`은 별개 이슈로, 유력 원인은 iOS WKWebView stale connection(비멱등 refresh 미재시도)입니다. 정확한 엔드포인트는 Sentry 트레이스 확인 후 별도 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 앱이 백그라운드에서 활성화될 때 사용자 프로필 정보와 인증 상태가 더욱 정확하게 새로고침됩니다. 브라우저 탭 전환 후 앱으로 돌아올 때 세션 정보가 올바르게 동기화되어 로그인 상태가 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->