### PR TITLE
feat(error-reporting): 에러를 Discord 웹훅으로도 전송 (Sentry 병행 sink)

### DIFF
--- a/src/app/api/client-error/route.ts
+++ b/src/app/api/client-error/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { ENV } from '@/config/environment';
+
+export const dynamic = 'force-dynamic';
+
+// 클라이언트(reportClientError)에서 받은 예외를 Discord 웹훅으로 포워딩하는 서버 프록시.
+// 웹훅 URL 은 서버 env(DISCORD_ERROR_WEBHOOK_URL)로만 보관 — 클라 번들 노출/CORS 회피.
+// 미설정 시 조용히 no-op. 어떤 경우에도 클라이언트엔 204 반환(보고 실패가 앱을 깨면 안 됨).
+
+interface ClientErrorPayload {
+  name?: string;
+  message?: string;
+  stack?: string;
+  context?: Record<string, unknown>;
+  url?: string;
+  userAgent?: string;
+  ts?: string;
+}
+
+const DISCORD_TIMEOUT_MS = 3_000;
+
+// Discord embed field value 는 최대 1024자. 코드블록 래핑(약 8자) 여유까지 고려해 보수적으로 자른다.
+function clip(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+export async function POST(request: Request) {
+  if (!ENV.DISCORD_ERROR_WEBHOOK_URL) {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  let body: ClientErrorPayload;
+  try {
+    body = (await request.json()) as ClientErrorPayload;
+  } catch {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const name = clip(String(body.name ?? 'Error'), 100);
+  const message = clip(String(body.message ?? ''), 800);
+  const stack = clip(String(body.stack ?? ''), 1000);
+  const url = clip(String(body.url ?? ''), 500) || '(none)';
+  const ua = clip(String(body.userAgent ?? ''), 300) || '(none)';
+  const scope = body.context && typeof body.context.scope === 'string' ? body.context.scope : 'unknown';
+  const ctxJson = body.context ? clip(JSON.stringify(body.context), 900) : '';
+
+  const embed = {
+    title: clip(`${name}: ${message}`, 256),
+    color: 0xff5751,
+    fields: [
+      { name: 'scope', value: scope, inline: true },
+      { name: 'URL', value: url },
+      ...(ctxJson ? [{ name: 'context', value: `\`\`\`json\n${ctxJson}\n\`\`\`` }] : []),
+      ...(stack ? [{ name: 'stack', value: `\`\`\`\n${stack}\n\`\`\`` }] : []),
+      { name: 'UA', value: ua },
+    ],
+    timestamp: typeof body.ts === 'string' ? body.ts : new Date().toISOString(),
+  };
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), DISCORD_TIMEOUT_MS);
+    await fetch(ENV.DISCORD_ERROR_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: '척척학사 에러봇', embeds: [embed] }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeoutId));
+  } catch {
+    // 웹훅 전송 실패/타임아웃은 무시.
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -3,10 +3,12 @@
 import { useEffect } from 'react';
 import NextError from 'next/error';
 import * as Sentry from '@sentry/nextjs';
+import { reportClientError } from '@/lib/error-reporting/reportClientError';
 
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
   useEffect(() => {
     Sentry.captureException(error);
+    reportClientError(error, { scope: 'global-error-boundary' });
   }, [error]);
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from '@/features/auth/contexts/AuthContext';
 import { AnalyticsProvider } from '@/lib/analytics';
 import { RemoteConfigProvider } from '@/lib/remote-config';
 import MaintenancePage from '@/components/MaintenancePage';
+import { GlobalErrorReporter } from '@/lib/error-reporting';
 import '../styles/global.scss';
 
 export const metadata: Metadata = {
@@ -79,6 +80,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
             </AnalyticsProvider>
           </AuthProvider>
         )}
+        <GlobalErrorReporter />
         <Analytics />
         {/* Cloudflare Web Analytics: 스크립트 삽입 */}
         <Script

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -98,6 +98,8 @@ export const ENV = {
   SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN ?? '',
   SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN ?? '',
   AMPLITUDE_API_KEY: process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY ?? '',
+  // 에러 웹훅 (서버 전용 시크릿). 미설정 시 /api/client-error 가 no-op — Sentry 와 병행 sink.
+  DISCORD_ERROR_WEBHOOK_URL: process.env.DISCORD_ERROR_WEBHOOK_URL ?? '',
 
   // Firebase RemoteConfig (Web 신설, prod 환경만 활성화)
   // 키 미설정 시 SDK init 자체를 silent skip — `useRemoteConfig` 가 defaultValue 그대로 반환.

--- a/src/lib/error-reporting/GlobalErrorReporter.tsx
+++ b/src/lib/error-reporting/GlobalErrorReporter.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+import { reportClientError } from './reportClientError';
+
+// 전역 미처리 예외(window error)와 미처리 Promise 거부(unhandledrejection)를 Discord 웹훅으로도
+// 보고한다 (Sentry 와 병행). 렌더 출력 없음 — 핸들러 등록 전용. 루트 layout 에 1회 마운트.
+export function GlobalErrorReporter() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      reportClientError(event.error ?? new Error(event.message), { scope: 'window.onerror' });
+    };
+    const onRejection = (event: PromiseRejectionEvent) => {
+      reportClientError(event.reason, { scope: 'unhandledrejection' });
+    };
+
+    window.addEventListener('error', onError);
+    window.addEventListener('unhandledrejection', onRejection);
+    return () => {
+      window.removeEventListener('error', onError);
+      window.removeEventListener('unhandledrejection', onRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/lib/error-reporting/index.ts
+++ b/src/lib/error-reporting/index.ts
@@ -1,0 +1,3 @@
+export { reportClientError } from './reportClientError';
+export type { ClientErrorContext } from './reportClientError';
+export { GlobalErrorReporter } from './GlobalErrorReporter';

--- a/src/lib/error-reporting/reportClientError.ts
+++ b/src/lib/error-reporting/reportClientError.ts
@@ -1,0 +1,80 @@
+// 클라이언트 예외를 Sentry 와 별개로 Discord 웹훅(서버 프록시 /api/client-error)으로도 전송한다.
+// fire-and-forget — 절대 throw 하지 않으며, 동일 에러 폭주를 막기 위해 시그니처 기반으로 throttle 한다.
+// 웹훅 URL 은 서버(/api/client-error)에서만 사용 — 클라이언트엔 노출되지 않는다.
+
+const DEDUPE_WINDOW_MS = 60_000;
+const MAX_TRACKED = 50;
+const recentlySent = new Map<string, number>();
+
+export interface ClientErrorContext {
+  /** 발생 위치/종류 식별용 (예: 'api', 'window.onerror'). */
+  scope?: string;
+  [key: string]: unknown;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+  try {
+    return new Error(JSON.stringify(error));
+  } catch {
+    return new Error('Unknown non-serializable error');
+  }
+}
+
+// 같은 시그니처(이름+메시지)는 1분에 1회만 전송 — Discord rate limit/스팸 방지.
+function shouldSend(signature: string): boolean {
+  const now = Date.now();
+  const last = recentlySent.get(signature);
+  if (last !== undefined && now - last < DEDUPE_WINDOW_MS) {
+    return false;
+  }
+  recentlySent.set(signature, now);
+  if (recentlySent.size > MAX_TRACKED) {
+    const oldest = recentlySent.keys().next().value;
+    if (oldest !== undefined) {
+      recentlySent.delete(oldest);
+    }
+  }
+  return true;
+}
+
+export function reportClientError(error: unknown, context?: ClientErrorContext): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    const err = toError(error);
+    const name = err.name || 'Error';
+    const message = err.message || 'Unknown error';
+    const signature = `${name}:${message}`.slice(0, 200);
+    if (!shouldSend(signature)) {
+      return;
+    }
+
+    const payload = {
+      name,
+      message: message.slice(0, 1000),
+      stack: (err.stack ?? '').slice(0, 1500),
+      context: context ?? {},
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      ts: new Date().toISOString(),
+    };
+
+    void fetch('/api/client-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    }).catch(() => {
+      // 보고 전송 실패는 무시 — 에러 보고가 앱 흐름을 깨면 안 됨.
+    });
+  } catch {
+    // 어떤 경우에도 throw 하지 않는다.
+  }
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -8,6 +8,7 @@ import {
   User as UserApi,
 } from '@/shared/api/domain';
 import { getUserMessage } from '../user-messages';
+import { reportClientError } from '@/lib/error-reporting/reportClientError';
 import { createApiConfig } from './configs/httpConfig';
 import type { ErrorResponseWrapper } from './data-contracts';
 import { ApiError } from './errors';
@@ -39,6 +40,8 @@ export const createApiClient = <T extends new (...args: any) => any>(ApiClass: T
 
           return res;
         } catch (error) {
+          // Sentry 와 병행해 Discord 웹훅(서버 프록시)으로도 보고. 동일 시그니처는 throttle 됨.
+          reportClientError(error, { scope: 'api', method: key });
           if (error instanceof ApiError) {
             throw error;
           }


### PR DESCRIPTION
## 요약
에러 리포트를 Sentry 외에 **Discord 채널에서 바로** 볼 수 있도록 병행 sink를 추가합니다. (웹뷰 `NETWORK_ERROR` 디버깅 목적)

## 동작
- 클라이언트 예외 → `reportClientError` → **서버 프록시 `POST /api/client-error`** → Discord 웹훅
- 웹훅 URL은 **서버 env `DISCORD_ERROR_WEBHOOK_URL`(시크릿)** 로만 보관 → 클라 번들 노출/CORS 회피
- **미설정 시 자동 no-op** (기능 off, 안전)

## 커버리지 (모든 예외 지향)
- `GlobalErrorReporter`: `window.onerror` + `unhandledrejection` → 미처리 예외·거부
- `client.ts` API catch: `NETWORK_ERROR` 등 모든 API 호출 실패
- `global-error.tsx`: 최상위 React 에러 바운더리
- Sentry `captureException`/설정은 **미변경** — 병행만 추가

## 스팸/안전
- 동일 시그니처(이름+메시지) **1분 1회 throttle/dedupe**
- fire-and-forget, 절대 throw 안 함, 페이로드 size clip(Discord field 한도 준수), 웹훅 전송 3s 타임아웃
- 클라엔 항상 204

## 설정 필요
`DISCORD_ERROR_WEBHOOK_URL`을 서버 env(.env / wrangler `vars` 또는 secret)에 Discord 웹훅 URL로 설정해야 전송됩니다.

## 검증
- [x] `type-check` 0
- [x] `lint` 0 errors (기존 warning만)
- [x] test 33/33

## 참고 — v1 범위
business-error를 명시적으로 `captureException` 하는 일부 호출부(bridge, usePortalLinkFailure 등)는 v1에서 별도 tee하지 않았습니다(window 핸들러 / API catch로 대부분 커버). 필요 시 후속에서 `reportException` 래퍼로 전수 tee 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
