### PR TITLE
feat(analytics): 학번/학과 User Property 세팅 (PII 정책 파기 반영)

### DIFF
--- a/src/app/(main)/main/page.tsx
+++ b/src/app/(main)/main/page.tsx
@@ -8,6 +8,7 @@ import {
   SyncUpdateButton,
 } from '@/features/dashboard/components';
 import { useRefreshProfileOnVisible } from '@/features/dashboard/hooks/useRefreshProfileOnVisible';
+import { UserPropertiesSync } from '@/features/dashboard/components/UserPropertiesSync/UserPropertiesSync';
 import AsyncBoundary from '@/shared/components/AsyncBoundary';
 
 const Home = () => {
@@ -15,6 +16,9 @@ const Home = () => {
 
   return (
     <>
+      <AsyncBoundary>
+        <UserPropertiesSync />
+      </AsyncBoundary>
       <AsyncBoundary>
         <ProfileCard />
       </AsyncBoundary>

--- a/src/app/(mpa)/mpa/home/page.tsx
+++ b/src/app/(mpa)/mpa/home/page.tsx
@@ -9,6 +9,7 @@ import {
   SyncUpdateButton,
 } from '@/features/dashboard/components';
 import { useRefreshProfileOnVisible } from '@/features/dashboard/hooks/useRefreshProfileOnVisible';
+import { UserPropertiesSync } from '@/features/dashboard/components/UserPropertiesSync/UserPropertiesSync';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { navigateNative } from '@/lib/webview';
 import AsyncBoundary from '@/shared/components/AsyncBoundary';
@@ -30,6 +31,9 @@ const MpaHome = () => {
 
   return (
     <>
+      <AsyncBoundary>
+        <UserPropertiesSync />
+      </AsyncBoundary>
       <AsyncBoundary>
         <ProfileCard />
       </AsyncBoundary>

--- a/src/features/dashboard/components/UserPropertiesSync/UserPropertiesSync.tsx
+++ b/src/features/dashboard/components/UserPropertiesSync/UserPropertiesSync.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getAdmissionYear, getDepartmentName } from '@/features/academic/utils/profileUtils';
+import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
+import { setUserProperties } from '@/lib/analytics';
+
+// 로그인 사용자의 프로필 기반 Amplitude UserProperty(학번/학과 등)를 세팅한다. 렌더 출력 없음.
+// useProfileQuery(suspense) 데이터에 의존하므로 AsyncBoundary 안에서 마운트할 것.
+// 키 이름은 Notion 텍소노미와 대조해 확정 필요(쉽게 rename 가능).
+export function UserPropertiesSync() {
+  const { data: profile } = useProfileQuery();
+
+  useEffect(() => {
+    setUserProperties({
+      student_code: profile.studentCode,
+      department: getDepartmentName(profile),
+      major: profile.majorName,
+      admission_year: getAdmissionYear(profile.studentCode),
+      grade_level: profile.gradeLevel,
+      ...(profile.dualMajorName ? { dual_major: profile.dualMajorName } : {}),
+    });
+  }, [profile]);
+
+  return null;
+}

--- a/src/lib/analytics/amplitude.ts
+++ b/src/lib/analytics/amplitude.ts
@@ -39,8 +39,9 @@ export function initAnalytics(): void {
 }
 
 /**
- * 로그인/세션 hydration 직후 호출. analyticsId 는 서버가 발급한 사용자 PK UUID.
- * 카카오 ID 나 학번 같은 의미있는 식별자는 PII 위험이 있으므로 절대 전달하지 말 것.
+ * 로그인/세션 hydration 직후 호출. analyticsId 는 서버가 발급한 사용자 PK UUID — user_id 로 사용.
+ * 학번/학과 등 사용자 식별 속성은 제품 결정에 따라 UserProperty(텍소노미)로 전송한다
+ * (userProperties.ts / UserPropertiesSync). 단, 비밀번호·카카오 원본 토큰 등 인증 시크릿은 절대 전달 금지.
  *
  * null/undefined 전달 시 user_id 만 클리어 (device_id 는 유지) — 세션 만료 등 *암묵적*
  * 로그아웃 경로에서 사용. 전체 reset 은 clearAuth 의 `resetAnalytics` 가 담당.

--- a/src/lib/analytics/userProperties.ts
+++ b/src/lib/analytics/userProperties.ts
@@ -7,15 +7,26 @@ import { setUserPropertiesInternal } from '@/lib/analytics/amplitude';
 export const WEB_VERSION = PACKAGE_VERSION;
 
 // 텍소노미 (Notion) — UserProperties.
-// `sys_platform` 은 웹/MPA WebView 둘 다 *절대 set 하지 않음* — 네이티브 앱 책임.
+// `sys_platform` / `sys_app_version` 은 웹/MPA WebView 둘 다 *절대 set 하지 않음* — 네이티브 앱 책임.
 // 크로스 플랫폼 식별은 동일한 analyticsId(user_id) 로 묶이며 device_id 는 분리.
-// `sys_app_version` 도 동일 — 네이티브 책임.
 //
-// TODO(backend): `timetable_count` / `course_count` 는 현재 StudentProfileSchema 에 부재 +
-// 시간표 기능 자체가 native-only. 백엔드가 profile 응답에 노출하거나 별도 endpoint 추가 후
-// `useProfileQuery` queryFn 에서 setUserProperties 호출 추가 (후속 PR).
+// 학번/학과 등 사용자 식별 속성은 제품 결정에 따라 전송한다(인증 시크릿 제외).
+// 프로필 기반 세팅은 UserPropertiesSync 컴포넌트가 담당. 키 이름은 Notion 텍소노미와 대조해 확정할 것.
+// TODO(backend): `timetable_count` / `course_count` 는 StudentProfileSchema 부재 + native-only → 백엔드 노출 후 추가.
 interface AllowedUserProperties {
   sys_web_version?: string;
+  /** 학번 */
+  student_code?: string;
+  /** 학과 (departmentName) */
+  department?: string;
+  /** 전공 (majorName) */
+  major?: string;
+  /** 입학년도 (학번 앞 2자리) */
+  admission_year?: string;
+  /** 학년 */
+  grade_level?: number;
+  /** 복수전공명 (있을 때만) */
+  dual_major?: string;
 }
 
 // 타입 안전 wrapper — 정의되지 않은 키 차단. 텍소노미가 확장되면 AllowedUserProperties 에 추가.


### PR DESCRIPTION
## 요약
체크리스트 미완료 항목 **User Property 세팅 (학번/학과 등)** 을 구현합니다. (식별자 PII 위험 정책을 제품 결정에 따라 파기)

## 변경
- **PII 정책 완화**: `amplitude.ts`의 "학번 절대 전달 금지" 주석을 제품 결정 반영해 갱신 — 학번/학과 등 식별 속성을 UserProperty로 전송 (단, 비밀번호·카카오 토큰 등 **인증 시크릿은 계속 금지**).
- `AllowedUserProperties` 확장: `student_code`, `department`, `major`, `admission_year`, `grade_level`, `dual_major`.
- `UserPropertiesSync` 컴포넌트: `useProfileQuery` 프로필로 `setUserProperties` 호출. web `/main`·`/mpa/home`의 `AsyncBoundary` 안에 마운트 (로그인 후 프로필 로드 시 1회). 렌더 출력 없음.

## ⚠️ 확인 필요 — 텍소노미 키
UserProperty 키 이름(`student_code` 등)은 제가 임의로 정한 것이며 **Notion 텍소노미 정의와 대조해 확정**해야 합니다(문서 접근 불가). 다르면 `AllowedUserProperties` + `UserPropertiesSync`에서 키만 rename하면 됩니다.

## 검증
- [x] `type-check` 0 · `lint` 0 · test 33/33
- 런타임: Amplitude User Look-Up에서 user property 도달 확인 (단, Amplitude 키 자체가 클라에 박혀야 함 → PR #215 + GH secret 선행 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
