### PR TITLE
fix(ci): Firebase NEXT_PUBLIC_* build env 주입 (prod 클라 inline 수정)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,6 +42,13 @@ jobs:
       NEXT_PUBLIC_JAVASCRIPT_KEY: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_JAVASCRIPT_KEY || secrets.STAGING_NEXT_PUBLIC_JAVASCRIPT_KEY }}
       NEXT_PUBLIC_SENTRY_DSN: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_SENTRY_DSN || secrets.STAGING_NEXT_PUBLIC_SENTRY_DSN }}
       NEXT_PUBLIC_AMPLITUDE_API_KEY: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_AMPLITUDE_API_KEY || secrets.STAGING_NEXT_PUBLIC_AMPLITUDE_API_KEY }}
+      # Firebase Web SDK config — prod-only (코드가 getEnvironment()!=='production' 시 init skip). staging 은 '' 주입.
+      NEXT_PUBLIC_FIREBASE_API_KEY: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_FIREBASE_API_KEY || '' }}
+      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || '' }}
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_FIREBASE_PROJECT_ID || '' }}
+      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || '' }}
+      NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || '' }}
+      NEXT_PUBLIC_FIREBASE_APP_ID: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_NEXT_PUBLIC_FIREBASE_APP_ID || '' }}
 
       REST_API_KEY: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_REST_API_KEY || secrets.STAGING_REST_API_KEY }}
       CLIENT_SECRET: ${{ needs.resolve-env.outputs.name == 'production' && secrets.PROD_CLIENT_SECRET || secrets.STAGING_CLIENT_SECRET }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -24,28 +24,15 @@
     "production": {
       "name": "cchaksa",
       "vars": {
-        // Amplitude prod 키는 build-time 주입(런타임 var 아님) — GH secret PROD_NEXT_PUBLIC_AMPLITUDE_API_KEY
-        // + deploy-cloudflare.yml env 로 설정. 미설정 시 SDK silent skip.
-        // (주의: 아래 NEXT_PUBLIC_FIREBASE_* 도 동일 — 런타임 var 라 클라 inline 안 됨. 별도 정리 필요.)
-
-        // Firebase Web SDK config (chukchuk-haksa 프로젝트).
+        // NEXT_PUBLIC_* (Amplitude / Firebase 등 클라 노출 키) 는 `next build` 시 클라 번들로 inline
+        // 되므로, 런타임 var 인 여기가 아니라 CI 빌드 env 로 주입한다 → deploy-cloudflare.yml 의 env
+        // + GH secret(PROD_NEXT_PUBLIC_AMPLITUDE_API_KEY, PROD_NEXT_PUBLIC_FIREBASE_* 등).
         //
-        // 보안 모델 — 아래 값들은 secret 이 아닌 공개 식별자임:
-        // - NEXT_PUBLIC_* 는 Next.js 가 클라이언트 번들에 inline 하므로 누구나 DevTools 로 볼 수 있음
-        // - Firebase 공식 가이드: https://firebase.google.com/docs/projects/api-keys — apiKey 는
-        //   "이 프로젝트 식별자" 역할일 뿐이며 secret 으로 취급하지 않음
-        // - 실질 보안은 Firebase Security Rules + GCP API key restrictions 가 담당
-        //
-        // 운영 책임 — GCP Console 에서 다음 제약을 적용해 둘 것 (코드로 강제 불가):
-        // 1. NEXT_PUBLIC_FIREBASE_API_KEY 에 HTTP referrer 제한 — cchaksa.com / *.cchaksa.com 만 허용
-        // 2. API 화이트리스트 — Firebase Remote Config API + 그 외 실제 사용 API 만 허용
-        // (위 제약 미적용 시 키 유출 시 quota 도용 위험 — README 또는 인프라 문서에도 명시 권장)
-        "NEXT_PUBLIC_FIREBASE_API_KEY": "AIzaSyC17SX9tKPXXgSfVlU9i5-N0d8IRzpI38g",
-        "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN": "chukchuk-haksa.firebaseapp.com",
-        "NEXT_PUBLIC_FIREBASE_PROJECT_ID": "chukchuk-haksa",
-        "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET": "chukchuk-haksa.firebasestorage.app",
-        "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "770530895115",
-        "NEXT_PUBLIC_FIREBASE_APP_ID": "1:770530895115:web:678ad6e34d151918742e0e"
+        // Firebase 값은 secret 이 아닌 공개 식별자지만(공식 가이드: apiKey 는 프로젝트 식별자),
+        // 빌드 주입이 필요해 GH secret 으로 관리. 실질 보안은 Firebase Security Rules + GCP API key
+        // restrictions 로 통제 — GCP Console 에서 적용 필수(코드로 강제 불가):
+        // 1. NEXT_PUBLIC_FIREBASE_API_KEY HTTP referrer 제한 — cchaksa.com / *.cchaksa.com 만 허용
+        // 2. API 화이트리스트 — Firebase Remote Config API 등 실제 사용 API 만 허용
       }
     }
   }


### PR DESCRIPTION
## 요약
Firebase RemoteConfig의 `NEXT_PUBLIC_FIREBASE_*` 키들이 prod 클라이언트 번들에 inline되지 않던 문제를 수정합니다. (#215 Amplitude 수정과 동일한 build-env 패턴 — Firebase는 머지 타이밍상 분리됨)

## 원인
`NEXT_PUBLIC_*`는 `next build` 시 클라 번들로 inline되는데, Firebase 6개 키가 CI 빌드 env가 아니라 `wrangler.jsonc` **런타임 var**에만 있었습니다 → prod 클라에 키가 비어 RemoteConfig init이 silent skip.

## 변경
- `deploy-cloudflare.yml` build `env`에 `NEXT_PUBLIC_FIREBASE_*` 6개 추가. **prod-only** (코드가 `getEnvironment()!=='production'` 시 init skip → staging은 `''` 주입).
- `wrangler.jsonc` production.vars에서 Firebase 키 제거(런타임 var 무의미) + GCP 보안 주석 유지.

## 머지 후 필요 — repo Settings → Secrets (production)
| Secret | 값 (기존 wrangler.jsonc 공개 식별자) |
|---|---|
| `PROD_NEXT_PUBLIC_FIREBASE_API_KEY` | `AIzaSyC17SX9tKPXXgSfVlU9i5-N0d8IRzpI38g` |
| `PROD_NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | `chukchuk-haksa.firebaseapp.com` |
| `PROD_NEXT_PUBLIC_FIREBASE_PROJECT_ID` | `chukchuk-haksa` |
| `PROD_NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` | `chukchuk-haksa.firebasestorage.app` |
| `PROD_NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID` | `770530895115` |
| `PROD_NEXT_PUBLIC_FIREBASE_APP_ID` | `1:770530895115:web:678ad6e34d151918742e0e` |

## 검증
- [x] `wrangler.jsonc` JSONC 유효 · `deploy-cloudflare.yml` YAML 유효

🤖 Generated with [Claude Code](https://claude.com/claude-code)
