### PR TITLE
style(ui): ConfirmDialog 버튼 세로 padding 확대 (12px → 16px)

### DIFF
--- a/src/components/ui/ConfirmDialog/ConfirmDialog.module.scss
+++ b/src/components/ui/ConfirmDialog/ConfirmDialog.module.scss
@@ -59,7 +59,7 @@
 .cancelButton,
 .confirmButton {
   flex: 1;
-  padding: spacing.$space-12;
+  padding: 16px spacing.$space-12;
   text-align: center;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
## 개요

PR #218 머지 직후 푸시되어 **머지에서 누락된 한 줄**을 다시 반영합니다.

`ConfirmDialog`의 취소/확인 버튼 세로 padding을 디자인 스펙에 맞춰 12px → 16px로 키웁니다.

```diff
.cancelButton, .confirmButton {
-  padding: spacing.$space-12;
+  padding: 16px spacing.$space-12;
}
```

## 배경

- #218(일반선택 info 아이콘/팝업)이 `b324381` 시점에 squash 머지됨
- 그 직후 푸시한 `11aa66a`(이 padding 변경)는 머지 스냅샷에 포함되지 못함
- #218은 이미 closed → 별도 PR로 복구

## 영향 범위

`ConfirmDialog`는 공용 컴포넌트로 2곳에서 사용됩니다 (둘 다 버튼 높이가 동일하게 커짐):
- MPA 포털 로그인 다이얼로그
- 일반선택 안내 팝업 (#218)

🤖 Generated with [Claude Code](https://claude.com/claude-code)