### PR TITLE
feat(graduation): 외국어인증 완료 카드화 + 복수전공 헤더 정렬

### DIFF
--- a/src/features/academic/components/progress/AreaProgressSection.module.scss
+++ b/src/features/academic/components/progress/AreaProgressSection.module.scss
@@ -10,6 +10,7 @@
 .dualMajorTitle {
   @include typography.body-md;
   @include typography.font-weight-bold;
+
   margin-top: spacing.$space-28;
   margin-bottom: spacing.$space-14;
   color: color.$gray-500;

--- a/src/features/academic/components/progress/AreaProgressSection.module.scss
+++ b/src/features/academic/components/progress/AreaProgressSection.module.scss
@@ -6,18 +6,13 @@
   margin-bottom: spacing.$space-12;
 }
 
-.dualMajorHeader {
-  margin-top: 28px;
-}
-
+// 섹션 헤더 — '전체 수강내역'·'필수 이수내역' 과 동일 스타일(body-md·bold·gray-500·여백)로 통일.
 .dualMajorTitle {
-  @include typography.body-lg;
+  @include typography.body-md;
   @include typography.font-weight-bold;
-  margin-bottom: spacing.$space-12;
-}
-
-.dualMajorSpacing {
-  margin-bottom: spacing.$space-20;
+  margin-top: spacing.$space-28;
+  margin-bottom: spacing.$space-14;
+  color: color.$gray-500;
 }
 
 // '일반선택' 학점 뒤 정보 아이콘 버튼 — 버튼 기본 스타일 제거 + 아이콘 수직 정렬.

--- a/src/features/academic/components/progress/AreaProgressSection.tsx
+++ b/src/features/academic/components/progress/AreaProgressSection.tsx
@@ -50,10 +50,7 @@ export default function AreaProgressSection() {
       {/* 복수전공 섹션 */}
       {dualMajorAreas.length > 0 && (
         <>
-          <div className={styles.dualMajorHeader}>
-            <div className={styles.dualMajorTitle}>복수전공 수강내역</div>
-          </div>
-          <div className={styles.dualMajorSpacing}></div>
+          <div className={styles.dualMajorTitle}>복수전공 수강내역</div>
           {dualMajorAreas.map((area, index) => (
             <div key={area.areaType}>
               <CourseAccordion

--- a/src/features/academic/components/progress/RequiredCompletionSection.module.scss
+++ b/src/features/academic/components/progress/RequiredCompletionSection.module.scss
@@ -62,6 +62,19 @@
   flex-shrink: 0;
 }
 
+// 완료 상태를 스크린 리더에 알리는 시각적 숨김 텍스트(✓ 아이콘엔 대체 텍스트가 없으므로).
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 // info.svg 가 #7F71FB(purple-100) 로 직접 색 지정됨 — AreaProgressSection.infoButton 과 동일 패턴.
 .infoButton {
   display: inline-flex;

--- a/src/features/academic/components/progress/RequiredCompletionSection.module.scss
+++ b/src/features/academic/components/progress/RequiredCompletionSection.module.scss
@@ -25,6 +25,22 @@
   @include radius.card-radius;
 }
 
+// 외국어인증 '완료' 시 — 완료 아코디언 카드(CourseAreaTrigger.completed)와 동일한 다크/퍼플 외형으로 통일.
+.completedCard {
+  background-color: color.$black-100;
+  border-color: color.$black-100;
+}
+
+.completedCard .name {
+  color: color.$purple-200;
+}
+
+// 완료 다크 카드에선 (i) 안내 아이콘을 흰색으로. info.svg 가 stroke 색(#7F71FB) 고정이라
+// color/currentColor 로는 못 바꿔 filter 로 흰색화(다른 info 아이콘 사용처엔 영향 없음).
+.completedCard .infoButton {
+  filter: brightness(0) invert(1);
+}
+
 .name {
   color: color.$black-100;
 
@@ -41,8 +57,9 @@
   color: color.$gray-100;
 }
 
-.completed {
-  color: color.$purple-100;
+// 완료 ✓ 아이콘(check-status-on) — 다른 완료 카드와 동일.
+.check {
+  flex-shrink: 0;
 }
 
 // info.svg 가 #7F71FB(purple-100) 로 직접 색 지정됨 — AreaProgressSection.infoButton 과 동일 패턴.

--- a/src/features/academic/components/progress/RequiredCompletionSection.tsx
+++ b/src/features/academic/components/progress/RequiredCompletionSection.tsx
@@ -23,7 +23,11 @@ export default function RequiredCompletionSection() {
       <div className={`${styles.row} ${isFulfilled ? styles.completedCard : ''}`}>
         <span className={styles.name}>외국어인증제도</span>
         {isFulfilled ? (
-          <Icon name="check-status-on" className={styles.check} size={20} />
+          <>
+            <Icon name="check-status-on" className={styles.check} size={20} />
+            {/* ✓ 아이콘엔 텍스트가 없어 스크린 리더용 대체 텍스트 제공 (Icon 은 aria-label 미전달) */}
+            <span className={styles.srOnly}>완료</span>
+          </>
         ) : (
           <span className={`${styles.status} ${styles.incomplete}`}>미완료</span>
         )}

--- a/src/features/academic/components/progress/RequiredCompletionSection.tsx
+++ b/src/features/academic/components/progress/RequiredCompletionSection.tsx
@@ -20,11 +20,13 @@ export default function RequiredCompletionSection() {
     <>
       <div className={styles.title}>필수 이수내역</div>
 
-      <div className={styles.row}>
+      <div className={`${styles.row} ${isFulfilled ? styles.completedCard : ''}`}>
         <span className={styles.name}>외국어인증제도</span>
-        <span className={`${styles.status} ${isFulfilled ? styles.completed : styles.incomplete}`}>
-          {isFulfilled ? '완료' : '미완료'}
-        </span>
+        {isFulfilled ? (
+          <Icon name="check-status-on" className={styles.check} size={20} />
+        ) : (
+          <span className={`${styles.status} ${styles.incomplete}`}>미완료</span>
+        )}
         <button
           type="button"
           className={styles.infoButton}


### PR DESCRIPTION
## 변경 사항

- **외국어인증제도 완료 카드화**: `languageCertFulfilled === true` 일 때, 완료 아코디언 카드와 동일한 다크/퍼플 외형 + ✓(`check-status-on`) + (i) 안내로 표시. 미완료·동기화 전(`false`/`null`)은 기존 흰 카드 + "미완료" 유지.
- **완료 카드 (i) 아이콘 흰색**: `info.svg` 가 stroke 색(`#7F71FB`) 고정이라 `color`/`currentColor` 로는 못 바꿔, `.completedCard .infoButton` 에만 `filter` 로 흰색화 (다른 info 아이콘 사용처엔 영향 없음).
- **복수전공 수강내역 헤더 통일**: `전체 수강내역`·`필수 이수내역` 과 동일 스타일(`body-md`·bold·`gray-500`·mt 28 / mb 14)로 정렬. 불필요한 래퍼와 헤더 아래 20px 추가 스페이서 제거.

## 비고

- 펼침(아코디언 expand) 제외 — 외국어 인증은 통과 여부 boolean 뿐이라 카드 안에 펼칠 세부 데이터가 없음. 완료 카드의 *외형*만 다른 카드와 통일.
- 연필(수정) 제외 — 기능 미확정(백엔드 협의 후), 아이콘 에셋도 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일 개선**
  * 복수전공 섹션 제목의 글꼴 크기, 여백 및 색상이 조정되었습니다.
  * 이수 완료 상태 카드의 시각적 표현이 개선되었습니다.
  * 이수 완료 여부 표시가 체크 아이콘으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->