### PR TITLE
fix(auth): 미연동 MPA 사용자 /mpa/portal-login → / 강제 리다이렉트 + 대시보드 401 수정

### DIFF
--- a/src/app/(mpa)/mpa/home/page.tsx
+++ b/src/app/(mpa)/mpa/home/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/features/dashboard/components';
 import { useRefreshProfileOnVisible } from '@/features/dashboard/hooks/useRefreshProfileOnVisible';
 import { UserPropertiesSync } from '@/features/dashboard/components/UserPropertiesSync/UserPropertiesSync';
+import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { navigateNative } from '@/lib/webview';
 import AsyncBoundary from '@/shared/components/AsyncBoundary';
@@ -29,8 +30,13 @@ const MpaHome = () => {
     }
   };
 
+  // 미연동(신규·탈퇴 후 재로그인 등) 사용자가 네이티브에 의해 /mpa/home 으로 진입하면 대시보드 카드들이
+  // 미연동 상태로 백엔드를 호출해 "아직 포털과 연동되지 않은 사용자입니다"(401) 가 카드 수만큼 쏟아진다.
+  // web 의 /main 레이아웃과 동일하게 portal-link 게이트를 걸어, 미연동이면 카드를 렌더하지 않고
+  // /mpa/portal-login 으로 보낸다. (게이트가 false 를 보려면 GET /api/session 이 미연동 세션을 destroy
+  // 하지 않고 isPortalLinked:false 로 응답해야 한다 — 동반 수정: src/app/api/session/route.ts)
   return (
-    <>
+    <ProtectedRoute requirePortalLinked={true} portalLinkRedirectTo={ROUTES.MPA.PORTAL_LOGIN}>
       <AsyncBoundary>
         <UserPropertiesSync />
       </AsyncBoundary>
@@ -53,7 +59,7 @@ const MpaHome = () => {
       <AsyncBoundary>
         <DualMajorRequirementCard onNavigate={goGraduation} />
       </AsyncBoundary>
-    </>
+    </ProtectedRoute>
   );
 };
 

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -176,9 +176,22 @@ export async function GET() {
     probe = await probeStudentProfile(session.accessToken);
 
     if (probe === 'unauthorized') {
-      // refresh 가 발급한 토큰조차 거부 → 백엔드 상태 이상. 세션 폐기.
-      await session.destroy();
-      return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
+      // refresh 가 발급한 fresh 토큰조차 /api/student/profile 에서 401 → 두 갈래로 해석한다.
+      // - 이미 portal-link 가 확정됐던 세션(isPortalLinked === true): 새 토큰인데도 거부됨 →
+      //   백엔드 상태 이상으로 보고 세션 폐기.
+      // - portal-link 가 확정된 적 없는 세션(예: MPA POST 익스체인지가 불확정 probe 로 isPortalLinked
+      //   를 unset 으로 남긴 미연동 사용자): fresh 토큰이 거부되는 건 토큰이 죽어서가 아니라 백엔드가
+      //   spec(404) 대신 401 로 '미연동'을 표현하는 것 → web signin 경로가 isPortalLinked:false 를
+      //   심는 것과 동일하게 false 로 200 응답한다. destroy 하면 webview 가 /mpa/portal-login 진입
+      //   직후 '/' 로 강제 리다이렉트된다 (web 은 callback 이 false 를 심어 위 self-declaration 분기로 보호됨).
+      if (session.isPortalLinked === true) {
+        await session.destroy();
+        return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
+      }
+      if (session.isPortalLinked !== false) {
+        session.isPortalLinked = false;
+      }
+      return respondWithAuthenticated(session);
     }
 
     if (probe === 'not-linked') {

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -28,7 +28,7 @@ async function respondWithAuthenticated(session: IronSession<SessionData>) {
 
 export const dynamic = 'force-dynamic';
 
-const STUDENT_PROFILE_PROBE_TIMEOUT_MS = 3_000;
+const PORTAL_LINK_PROBE_TIMEOUT_MS = 3_000;
 // fast path 에서 토큰 잔여 시간 안전 마진. exp 가 지금 + 이 값 보다 멀리 있어야 probe 생략.
 // 60s 는 임의 — 너무 짧으면 fast path 도중 만료될 위험, 너무 길면 fast path 적중률 떨어짐.
 const FAST_PATH_TOKEN_BUFFER_MS = 60_000;
@@ -56,20 +56,25 @@ function hasTokenTimeLeft(accessToken: string, bufferMs: number): boolean {
   }
 }
 
-// 백엔드 `/api/student/profile` 호출 결과를 네 종류로 분류해서 반환한다.
-// - 'ok' (200)            → accessToken 유효 + 사용자가 portal-link 완료된 상태
-// - 'unauthorized' (401)  → accessToken 만료/무효. refresh 가 필요한 신호
-// - 'not-linked' (404)    → accessToken 유효 + 학생 프로필 없음 (S01, STUDENT_NOT_FOUND).
-//                            funnel 로 보내야 할 정상 상태이지 세션 destroy 사유가 아님.
-// - 'error' (그 외)       → 백엔드/네트워크 일시 오류 (5xx, timeout). refresh 시도해 expired-JWT hang 회복.
+// 백엔드 `GET /api/users/me` 한 번으로 토큰 유효성과 portal-link 여부를 함께 판정한다.
+// /api/users/me 는 "포털 연동 여부 조회"가 목적이라, 유효 토큰이면 연동/미연동과 무관하게
+// 200 + { data: { isPortalLinked } } 를 돌려준다 → 토큰 유효성(200 vs 401)과 연동 상태(isPortalLinked)를
+// 깨끗이 분리한다. (구 /api/student/profile probe 는 미연동을 404, production 에선 401 로 표현해
+// 토큰 무효와 구분되지 않았고, 그 모호함이 미연동 webview 사용자의 세션을 destroy 시켜 '/' 로 튕기는
+// 버그의 원인이었다.)
+// - 'ok' (200 + isPortalLinked:true)          → 토큰 유효 + 연동 완료
+// - 'not-linked' (200 + isPortalLinked:false)  → 토큰 유효 + 미연동. funnel 로 보내야 할 정상 상태이지
+//                                                 세션 destroy 사유가 아님
+// - 'unauthorized' (401)                       → accessToken 만료/무효. refresh 가 필요한 신호
+// - 'error' (그 외/타임아웃/형식이상)          → 백엔드/네트워크 일시 오류 (5xx, timeout). refresh 시도해 hang 회복
 //
-// GET 에서 토큰 유효성 검증과 isPortalLinked 승격을 한 번의 백엔드 호출로 수행하고,
+// GET 에서 토큰 유효성 검증과 isPortalLinked 판정을 한 번의 백엔드 호출로 수행하고,
 // POST 에서 세션 생성 시 isPortalLinked 초기값을 결정한다.
-async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
+async function probePortalLinkStatus(accessToken: string): Promise<ProbeResult> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), STUDENT_PROFILE_PROBE_TIMEOUT_MS);
+  const timeoutId = setTimeout(() => controller.abort(), PORTAL_LINK_PROBE_TIMEOUT_MS);
   try {
-    const response = await fetch(`${getApiBaseUrl()}/api/student/profile`, {
+    const response = await fetch(`${getApiBaseUrl()}/api/users/me`, {
       method: 'GET',
       headers: { Authorization: `Bearer ${accessToken}` },
       signal: controller.signal,
@@ -78,18 +83,24 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
     if (response.status === 401) {
       return 'unauthorized';
     }
-    if (response.status === 404) {
-      return 'not-linked';
+    if (!response.ok) {
+      return 'error';
     }
-    if (response.ok) {
-      return 'ok';
+    // 응답 래퍼: { success, data: { isPortalLinked }, message }. data.isPortalLinked 가 boolean 일 때만
+    // 신뢰한다. 형식 이상·파싱 실패는 'error' 로 떨궈 refresh 경로가 처리하게 한다.
+    const body = (await response.json().catch(() => null)) as {
+      data?: { isPortalLinked?: unknown };
+    } | null;
+    const linked = body?.data?.isPortalLinked;
+    if (typeof linked !== 'boolean') {
+      return 'error';
     }
-    return 'error';
+    return linked ? 'ok' : 'not-linked';
   } catch (error) {
     if (!(error instanceof Error && error.name === 'AbortError')) {
       captureException(error, {
-        tags: { scope: 'session', action: 'probeStudentProfile' },
-        extra: { endpoint: '/api/student/profile', timeoutMs: STUDENT_PROFILE_PROBE_TIMEOUT_MS },
+        tags: { scope: 'session', action: 'probePortalLinkStatus' },
+        extra: { endpoint: '/api/users/me', timeoutMs: PORTAL_LINK_PROBE_TIMEOUT_MS },
       });
     }
     return 'error';
@@ -100,14 +111,15 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
 
 // GET /api/session: 클라이언트 하이드레이션 진입점.
 // 1. 쿠키에서 토큰 꺼냄
-// 2. 백엔드 probe 로 유효성 검증
+// 2. 백엔드 probe(GET /api/users/me)로 토큰 유효성 + 연동 상태 판정
 // 3. probe 분기:
 //    - 'ok'                      → isPortalLinked true 로 승격, 200
-//    - 'not-linked'              → 토큰 유효, 학생 프로필만 없음. refresh 없이 false 로 200
+//    - 'not-linked'              → 토큰 유효 + 미연동. refresh 없이 false 로 200
 //    - session 이 unlinked 라고 자체 선언 + probe 가 'unauthorized'/'error'
-//        → fresh signin 직후 백엔드가 spec 외 status 반환하는 케이스 (401, 5xx 등).
-//           토큰 무효 신호가 아니라 미연동 사용자 응답일 뿐이므로 refresh/destroy 없이 false 로 200
-//    - 그 외 'unauthorized'/'error' (linked 상태에서 probe 실패) → 토큰 문제 가능성. refresh 시도
+//        → /me 일시 오류이거나, 만약 백엔드가 미연동에 비-spec 401 을 주더라도 그 토큰은 방금
+//           signin/refresh 로 발급된 fresh 한 것이므로 토큰 무효로 해석하면 안 됨. destroy 없이 false 로
+//           200 (방어적 fallback)
+//    - 그 외 'unauthorized'/'error' (linked/미상 상태에서 probe 실패) → 토큰 문제 가능성. refresh 시도
 // 4. refresh 실패 또는 refresh 후 재-probe 가 'unauthorized' (그리고 unlinked 자체 선언 아니면)
 //    → 세션 폐기 + 401
 //
@@ -115,18 +127,14 @@ async function probeStudentProfile(accessToken: string): Promise<ProbeResult> {
 // probe 가 401 을 못 받고 timeout 으로 'error' 떨어지는 케이스 관측됨 (Sentry CCHAKSA-56).
 // refresh 엔드포인트는 별도 refreshToken 으로 호출되어 expired-token hang 영향 없음 → 새 토큰 발급 가능.
 //
-// 'not-linked' (404, S01) 는 신규/포털 미연동 사용자의 정상 funnel 상태. 이걸 refresh/destroy 로
-// 처리하면 갓 signin 한 미연동 사용자가 /auth/success → GET /api/session → 401 → '/' 리다이렉트로
-// 튕기는 버그가 발생. /portal-login 으로 보내야 하는 신호일 뿐 세션 무효 신호가 아님.
-//
-// 추가: 백엔드가 spec 과 달리 미연동 사용자에게 401/5xx 를 줘도 (실제 production 관측) session 이
-// 자체적으로 isPortalLinked:false 라고 선언한 상태면 — 그 토큰은 방금 signin/refresh 로 발급된
-// 신선한 토큰이므로 토큰 무효 신호로 해석하면 안 됨. destroy 하지 않고 false 로 응답.
+// 'not-linked' 는 신규/포털 미연동 사용자의 정상 funnel 상태. 이걸 refresh/destroy 로 처리하면
+// 갓 signin 한 미연동 사용자가 /auth/success → GET /api/session → 401 → '/' 리다이렉트로 튕기는
+// 버그가 발생. /portal-login 으로 보내야 하는 신호일 뿐 세션 무효 신호가 아님.
 //
 // refresh 실패 시 분기 단순화: probe 가 'unauthorized' 든 'error' 든 무조건 세션 폐기 (단, 위의
 // unlinked 선언 케이스 제외). 사용자가 깨진 화면에 갇히는 것보다 로그인 화면으로 보내는 게 명확.
 //
-// isPortalLinked 는 probe 결과(`'ok'`)로만 true 로 승격 — 클라이언트 임의 값 신뢰 안 함.
+// isPortalLinked 는 probe(/api/users/me) 결과로만 결정 — 클라이언트 임의 값 신뢰 안 함.
 export async function GET() {
   const session = await getSession();
 
@@ -135,7 +143,7 @@ export async function GET() {
   }
 
   // Fast path: 이미 portal-link 승격됐고 토큰이 충분히 남아있으면 백엔드 probe 생략.
-  // 매 GET 마다 도는 probeStudentProfile (~200ms~3s) 이 isPortalLinked 변경 체감 지연의 주범.
+  // 매 GET 마다 도는 probePortalLinkStatus (~200ms~3s) 이 isPortalLinked 변경 체감 지연의 주범.
   // - isPortalLinked === true 일 때만 적용 (false → true 승격은 여전히 probe 필요)
   // - JWT exp 가 충분히 남았으면 만료 가능성 낮음 — backend revoke 케이스는 다음 API 호출의
   //   401 fallback 에서 잡혀 refresh 자동 발동 (이미 그 경로 존재)
@@ -144,9 +152,9 @@ export async function GET() {
     return respondWithAuthenticated(session);
   }
 
-  let probe = await probeStudentProfile(session.accessToken);
+  let probe = await probePortalLinkStatus(session.accessToken);
 
-  // 미연동 사용자 (S01) — 토큰은 유효. refresh/destroy 경로 진입 없이 즉시 응답.
+  // 미연동 사용자 — 토큰은 유효. refresh/destroy 경로 진입 없이 즉시 응답.
   if (probe === 'not-linked') {
     if (session.isPortalLinked !== false) {
       session.isPortalLinked = false;
@@ -154,9 +162,9 @@ export async function GET() {
     return respondWithAuthenticated(session);
   }
 
-  // session 이 unlinked 라고 자체 선언한 상태에서 probe 가 실패하면 — backend 가 spec 외
-  // status (401/5xx) 로 미연동 사용자를 표현했을 가능성이 큼. 토큰은 fresh 한데 destroy 하면
-  // 사용자가 / 로 튕김. 토큰 신뢰하고 false 로 응답.
+  // session 이 unlinked 라고 자체 선언한 상태에서 probe 가 실패하면 — /me 일시 오류이거나, 백엔드가
+  // 미연동 사용자에게 비-spec 401 을 주는 경우라도, 토큰은 fresh 한데 destroy 하면 사용자가 / 로
+  // 튕긴다. 토큰 신뢰하고 false 로 응답 (방어적 fallback).
   if (probe !== 'ok' && session.isPortalLinked === false) {
     return respondWithAuthenticated(session);
   }
@@ -173,25 +181,13 @@ export async function GET() {
     session.refreshToken = refreshed.refreshToken;
 
     // 새 토큰으로 probe 재시도 — 유효성 재확인 + isPortalLinked 판단.
-    probe = await probeStudentProfile(session.accessToken);
+    probe = await probePortalLinkStatus(session.accessToken);
 
     if (probe === 'unauthorized') {
-      // refresh 가 발급한 fresh 토큰조차 /api/student/profile 에서 401 → 두 갈래로 해석한다.
-      // - 이미 portal-link 가 확정됐던 세션(isPortalLinked === true): 새 토큰인데도 거부됨 →
-      //   백엔드 상태 이상으로 보고 세션 폐기.
-      // - portal-link 가 확정된 적 없는 세션(예: MPA POST 익스체인지가 불확정 probe 로 isPortalLinked
-      //   를 unset 으로 남긴 미연동 사용자): fresh 토큰이 거부되는 건 토큰이 죽어서가 아니라 백엔드가
-      //   spec(404) 대신 401 로 '미연동'을 표현하는 것 → web signin 경로가 isPortalLinked:false 를
-      //   심는 것과 동일하게 false 로 200 응답한다. destroy 하면 webview 가 /mpa/portal-login 진입
-      //   직후 '/' 로 강제 리다이렉트된다 (web 은 callback 이 false 를 심어 위 self-declaration 분기로 보호됨).
-      if (session.isPortalLinked === true) {
-        await session.destroy();
-        return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
-      }
-      if (session.isPortalLinked !== false) {
-        session.isPortalLinked = false;
-      }
-      return respondWithAuthenticated(session);
+      // refresh 가 발급한 fresh 토큰조차 /me 에서 401 → 미연동이면 'not-linked' 로 왔을 것이므로,
+      // 401 은 진짜 토큰 무효(백엔드 상태 이상)다. 세션 폐기.
+      await session.destroy();
+      return NextResponse.json({ error: 'SESSION_EXPIRED' }, { status: 401 });
     }
 
     if (probe === 'not-linked') {
@@ -224,10 +220,10 @@ interface SessionExchangeBody {
 
 // 네이티브 앱이 보유한 ac/re 토큰을 cchaksa_session 쿠키로 익스체인지.
 // 시퀀스: docs/mpa-school-link-handoff.md
-// isPortalLinked 는 요청 바디에서 받지 않고 백엔드 probe 결과로 결정 — 클라이언트 임의 값으로
-// 세션 승격되는 경로 차단. probe 가 만료(401)/일시오류(timeout·5xx)면 refreshToken 으로 재발급 후
-// 재-probe 한다 (GET 과 동일) — cold start 직후 연동 사용자가 미연동으로 오판되는 것을 막는다.
-// TODO(backend): 토큰 진위 검증 엔드포인트가 추가되면 sealData 직전 호출해 위조 토큰 차단.
+// isPortalLinked 는 요청 바디에서 받지 않고 백엔드 probe(GET /api/users/me) 결과로 결정 — 클라이언트
+// 임의 값으로 세션 승격되는 경로 차단. probe 가 만료(401)/일시오류(timeout·5xx)면 refreshToken 으로
+// 재발급 후 재-probe 한다 (GET 과 동일) — cold start 직후 연동 사용자가 미연동으로 오판되는 것을 막는다.
+// /api/users/me 는 @secure 라 200 응답 자체가 토큰 진위 1차 검증을 겸한다 (docs B1).
 export async function POST(request: Request) {
   let body: SessionExchangeBody;
   try {
@@ -250,16 +246,16 @@ export async function POST(request: Request) {
   let activeAccessToken = accessToken;
   let activeRefreshToken = refreshToken;
   let [probe, analyticsId] = await Promise.all([
-    probeStudentProfile(accessToken),
+    probePortalLinkStatus(accessToken),
     fetchAnalyticsIdFromBackend(accessToken),
   ]);
 
   // cold start 등으로 native 가 보유한 accessToken 이 만료(401)거나 백엔드 일시오류(timeout·5xx)면,
-  // 단일 probe 결과로 isPortalLinked=false 를 굳히지 않는다 — refreshToken 으로 재발급 후 재-probe.
+  // 단일 probe 결과로 isPortalLinked 를 굳히지 않는다 — refreshToken 으로 재발급 후 재-probe.
   // 이게 없으면 이미 연동된 사용자가 cold start 직후 미연동으로 오판되고, 그 false 가 세션에 저장돼
-  // 이후 GET 의 'unlinked 자체 선언' 분기(아래 GET 주석 참조)가 refresh 를 건너뛰어 false 가 고착,
+  // 이후 GET 의 'unlinked 자체 선언' 분기(위 GET 주석 참조)가 refresh 를 건너뛰어 false 가 고착,
   // 네이티브가 "학교 연동을 하시겠습니까?" 프롬프트를 잘못 띄운다. (GET 의 refresh+re-probe 와 동일 원리.)
-  // 'not-linked'(404)는 정상 미연동이라 refresh 하지 않는다. refresh 실패/재-probe 불확정이면
+  // 'not-linked'(미연동)는 정상 상태라 refresh 하지 않는다. refresh 실패/재-probe 불확정이면
   // 아래에서 isPortalLinked 를 저장하지 않고 unset 으로 남겨 다음 GET 이 정상 refresh 로 복구한다.
   if (probe !== 'ok' && probe !== 'not-linked') {
     const refreshed = await refreshTokensFromBackend(refreshToken);
@@ -267,7 +263,7 @@ export async function POST(request: Request) {
       activeAccessToken = refreshed.accessToken;
       activeRefreshToken = refreshed.refreshToken;
       [probe, analyticsId] = await Promise.all([
-        probeStudentProfile(activeAccessToken),
+        probePortalLinkStatus(activeAccessToken),
         fetchAnalyticsIdFromBackend(activeAccessToken),
       ]);
     }


### PR DESCRIPTION
## 문제
탈퇴/미가입(미연동) 사용자가 웹뷰(MPA)에서 로그인 후 `/mpa/portal-login` 으로 진입하면 웹이 `/` 로 강제 리다이렉트됨. 더불어 `/mpa/home` 대시보드 카드들이 `아직 포털과 연동되지 않은 사용자입니다`(401)를 카드 수만큼 throw. **순수 웹(funnel)에서는 정상** — 웹은 `/auth/callback` 이 signin 응답의 `isPortalLinked=false` 를 세션에 심어 보호되기 때문.

## 원인
1. **probe 모호성.** `GET/POST /api/session` 이 `isPortalLinked` 를 `/api/student/profile` 로 추론하는데, 백엔드가 미연동을 401(또는 404)로 표현 → "토큰 무효"와 구분 불가. MPA `POST` 익스체인지는 signin 응답이 없어 probe 불확정 시 `isPortalLinked` 를 unset 으로 남김 → 다음 `GET` 이 refresh→재probe 401→`session.destroy()`→401→AuthContext `accessToken=null`→`ProtectedRoute` 가 `/` 로 리다이렉트.
2. **웹뷰 home 게이트 부재.** `(mpa)` 레이아웃은 `requirePortalLinked` 없는 bare `ProtectedRoute` 라 미연동 사용자가 `/mpa/home` 대시보드를 렌더 → 카드들이 401.

## 변경
- **probe 소스를 `GET /api/users/me` 로 교체** (`probeStudentProfile`→`probePortalLinkStatus`). `/me` 는 연동 여부 조회가 목적이라 유효 토큰이면 연동/미연동 무관 `200 + isPortalLinked` 반환 → 토큰 유효성(200 vs 401)과 연동 상태를 분리. 미연동이 `'not-linked'` 로 떨어져 `POST` 가 false 를 확정 저장하고 `GET` 이 destroy 없이 false 응답. `{ data: { isPortalLinked } }` 래퍼 파싱. (`/me` 가 `@secure` 라 docs B1 토큰 진위 검증도 겸함.)
- **`/mpa/home` 게이트 추가** (`requirePortalLinked` + `portalLinkRedirectTo=/mpa/portal-login`, 웹 `/main` 과 동일) → 미연동이면 대시보드 미렌더 + portal-login 으로 라우팅.

## 검증
- `yarn type-check` / `yarn lint` 통과
- 엣지 케이스 추적: 만료토큰 / cold-start hang(CCHAKSA-56) / 위조토큰 / POST 익스체인지 — 기존 복구 로직 보존

## ⚠️ 머지 전 확인 (린치핀)
이 수정은 **`/api/users/me` 가 미연동 사용자에게 401 이 아닌 `200 + isPortalLinked:false`** 를 준다는 전제 위에 있음. dv 에서 미연동 토큰으로 확인 필요:

```bash
curl -i -H "Authorization: Bearer <미연동 accessToken>" https://dev.api.cchaksa.com/api/users/me
# 기대: 200 + {"data":{"isPortalLinked":false}}
```

만약 401 이면 엔드포인트 교체만으로는 부족 → 방어 fallback(never-linked 세션의 post-refresh 401 을 false 취급) 한 줄 추가 필요.

## 테스트 플랜
- [ ] dv 웹뷰: 미연동 사용자 로그인 → `/mpa/portal-login` 유지 (`/` 튕김 없음)
- [ ] dv 웹뷰: 미연동 사용자 `/mpa/home` 진입 → `/mpa/portal-login` 으로 라우팅, 401 폭주 없음
- [ ] 연동 사용자: `/mpa/home` 대시보드 정상
- [ ] 순수 웹(funnel): 로그인 → portal-login 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 포털 연동 계정 확인 프로세스를 강화했습니다. 포털이 미연동된 사용자는 대시보드 접근 시 포털 연동 페이지로 자동 리다이렉트됩니다.
  * 세션 유효성 검증 및 토큰 관리 로직을 개선하여 인증 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->