### PR TITLE
fix(mpa): webview UX — link timeout recovery, resync→home, delete flow, spacing, rendered signal

### DIFF
--- a/src/app/(funnel)/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/app/(funnel)/components/LoadingScreen/LoadingScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { isInWebView } from '@/lib/webview';
 import styles from './LoadingScreen.module.scss';
 
 const LOADING_STATES = [
@@ -22,6 +23,9 @@ const LoadingScreen = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [playCount, setPlayCount] = useState(0);
   const [fadeState, setFadeState] = useState<'in' | 'out'>('in');
+  // 웹뷰에선 OS 가 실제 홈 인디케이터를 그리므로 아래 장식용 가짜 인디케이터는 숨긴다.
+  // SSR/hydration 불일치(서버엔 window 없음)를 피하려 마운트 후에 판별한다.
+  const [isWebView, setIsWebView] = useState(false);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -49,6 +53,10 @@ const LoadingScreen = () => {
     };
   }, [playCount]);
 
+  useEffect(() => {
+    setIsWebView(isInWebView());
+  }, []);
+
   const currentState = LOADING_STATES[playCount % LOADING_STATES.length];
 
   return (
@@ -67,7 +75,7 @@ const LoadingScreen = () => {
       </main>
 
       <div className={styles.bottomBar}>
-        <div className={styles.indicator} />
+        {!isWebView && <div className={styles.indicator} />}
       </div>
     </div>
   );

--- a/src/app/(funnel)/scraping/page.tsx
+++ b/src/app/(funnel)/scraping/page.tsx
@@ -26,13 +26,18 @@ export default function ScrapingPage() {
   const jobStatus = jobStatusData?.status;
   const jobDetail = jobStatusData;
 
-  const { data: summaryData } = usePortalLinkSummary(jobId, jobStatus);
+  // 폴링 succeeded 시(studentInfo 확보) + 3분 타임아웃 회복 확인 시 summary 를 조회한다.
+  const summaryQuery = usePortalLinkSummary(jobId, jobStatus === 'succeeded' || isTimedOut);
+  const summaryData = summaryQuery.data;
   const handledRef = useRef(false);
 
   const { failureMessage } = usePortalLinkFailure({
     jobStatus,
     jobDetail,
     isTimedOut,
+    summaryResolved: summaryQuery.isFetched,
+    // 성공 판정(studentInfo)과 동일 신호로 맞춰, 성공이 확정되면 타임아웃 실패가 절대 안 뜨게 한다.
+    recovered: Boolean(summaryData?.studentInfo),
     loginRoute: ROUTES.FUNNEL.PORTAL_LOGIN,
   });
 

--- a/src/app/(mpa)/layout.module.scss
+++ b/src/app/(mpa)/layout.module.scss
@@ -9,3 +9,17 @@
   @include utilities.content-padding;
   @include utilities.safe-area-bottom(spacing.$space-36);
 }
+
+// 졸업요건: 웹 /graduation-progress 와 동일하게. GraduationProgressContent 가 자체 패딩(20/16)을
+// 가지므로 content-padding 을 빼 이중 패딩(40px)을 막고, 헤더 아래가 독립 스크롤되도록 한다.
+.contentScroll {
+  flex: 1;
+  overflow-y: auto;
+  @include utilities.safe-area-bottom(spacing.$space-48);
+}
+
+// 탈퇴: 웹 /delete(setting-layout) 와 동일하게. 수평 패딩만 두고, 하단/높이는 페이지(.container)가
+// 직접 처리하므로 레이아웃에서 추가 safe-area-bottom 을 더하지 않는다.
+.contentPlain {
+  @include utilities.content-padding;
+}

--- a/src/app/(mpa)/layout.tsx
+++ b/src/app/(mpa)/layout.tsx
@@ -7,11 +7,24 @@ import { ROUTES } from '@/constants/routes';
 import GraduationNavigationHeader from '@/features/academic/components/progress/GraduationNavigationHeader';
 import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { isInWebView, redirectToHome } from '@/lib/webview';
 import styles from './layout.module.scss';
 
 export default function MpaLayout({ children }: PropsWithChildren) {
   const pathname = usePathname();
   const router = useInternalRouter();
+
+  // 재연동 진입점은 홈이다. 연동 실패 후 router.back() 은 jobId 가 비워진 stale /mpa/resync/scraping
+  // ("연동 정보를 찾을 수 없어요") 로 떨어져 로그인↔스크래핑 루프에 갇힌다. resync/login 의 < 는
+  // 히스토리 대신 항상 홈으로 보낸다 (성공 경로와 동일: webview 는 네이티브에 위임, web 은 라우팅).
+  const goHome = () => {
+    // webview 는 네이티브에 홈 이동을 위임한다. 브리지 송출 실패(미존재/예외)면 사용자가 멈추지
+    // 않도록 web 경로와 동일하게 라우팅 fallback (성공 경로의 done:portal-link 처리와 동일 패턴).
+    if (isInWebView() && redirectToHome()) {
+      return;
+    }
+    router.push(ROUTES.MPA.HOME);
+  };
 
   // mpa/home 만 Topbar 없음(네이티브 홈 헤더 사용). 그 외 페이지는 대응되는 웹 화면의 Topbar 를
   // 그대로 따른다. 뒤로가기는 useInternalRouter.back() 으로 — webview 에선 navigateBack 브릿지가
@@ -25,7 +38,7 @@ export default function MpaLayout({ children }: PropsWithChildren) {
       case ROUTES.MPA.ME:
         return <TopNavigation.Preset title="설정" type="back" onNavigationClick={() => router.back()} />;
       case ROUTES.MPA.RESYNC_LOGIN:
-        return <TopNavigation.Preset title="" type="back" onNavigationClick={() => router.back()} />;
+        return <TopNavigation.Preset title="" type="back" onNavigationClick={goHome} />;
       default:
         return null;
     }

--- a/src/app/(mpa)/layout.tsx
+++ b/src/app/(mpa)/layout.tsx
@@ -30,6 +30,19 @@ export default function MpaLayout({ children }: PropsWithChildren) {
   // 그대로 따른다. 뒤로가기는 useInternalRouter.back() 으로 — webview 에선 navigateBack 브릿지가
   // 함께 송출되고 웹 자체 뒤로가기도 수행된다. 펀널·로딩 페이지(portal-login·scraping·resync/scraping)는
   // 웹과 동일하게 Topbar 없음.
+  // 대응되는 웹 화면과 여백을 맞추기 위해 라우트별로 content 래퍼 스타일을 다르게 적용한다.
+  // (graduation-progress: 콘텐츠 자체 패딩이 있어 content-padding 제외 + 독립 스크롤 / delete: 추가 하단 여백 제외)
+  const contentClassName = (): string => {
+    switch (pathname) {
+      case ROUTES.MPA.GRADUATION_PROGRESS:
+        return styles.contentScroll;
+      case ROUTES.MPA.DELETE:
+        return styles.contentPlain;
+      default:
+        return styles.content;
+    }
+  };
+
   const renderTopbar = (): ReactNode => {
     switch (pathname) {
       case ROUTES.MPA.GRADUATION_PROGRESS:
@@ -51,7 +64,7 @@ export default function MpaLayout({ children }: PropsWithChildren) {
     <ProtectedRoute>
       <div className={styles.container}>
         {renderTopbar()}
-        <div className={styles.content}>{children}</div>
+        <div className={contentClassName()}>{children}</div>
       </div>
     </ProtectedRoute>
   );

--- a/src/app/(mpa)/layout.tsx
+++ b/src/app/(mpa)/layout.tsx
@@ -37,6 +37,9 @@ export default function MpaLayout({ children }: PropsWithChildren) {
         return <GraduationNavigationHeader />;
       case ROUTES.MPA.ME:
         return <TopNavigation.Preset title="설정" type="back" onNavigationClick={() => router.back()} />;
+      case ROUTES.MPA.DELETE:
+        // 탈퇴 확인 페이지. < 는 /mpa/me 로 복귀 (웹 /delete 와 동일한 제목/뒤로가기).
+        return <TopNavigation.Preset title="탈퇴하기" type="back" onNavigationClick={() => router.back()} />;
       case ROUTES.MPA.RESYNC_LOGIN:
         return <TopNavigation.Preset title="" type="back" onNavigationClick={goHome} />;
       default:

--- a/src/app/(mpa)/mpa/delete/page.tsx
+++ b/src/app/(mpa)/mpa/delete/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Image from 'next/image';
+import { FunnelHeadline } from '@/app/(funnel)/components';
+import { FixedButton } from '@/components/ui';
+import { withdraw } from '@/lib/webview';
+// 웹 /delete 와 동일한 확인 화면 레이아웃을 재사용한다.
+import styles from '@/app/(setting)/delete/page.module.scss';
+
+/**
+ * MPA 탈퇴 확인 페이지.
+ * /mpa/me 의 '탈퇴하기' 가 (네이티브 팝업/직접 bridge 가 아니라) 이 페이지로 이동하고,
+ * 여기서 '탈퇴하기' 버튼을 누르면 'withdraw' 브릿지 이벤트를 송출한다. 실제 탈퇴 처리는 네이티브가 수행한다.
+ */
+const MpaDeletePage = () => {
+  return (
+    <div className={styles.container}>
+      <div className="gap-14" />
+      <FunnelHeadline
+        title="척척학사를<br/>떠나시겠어요?"
+        description="다음 패치가 있기 전까지 재가입이 불가능합니다.<br/>척척학사에서 수집하는 개인 정보는<br/>탈퇴 즉시 폐기됩니다."
+      />
+      <div className={styles.imageWrapper}>
+        <Image src="/images/illustrations/Leave.png" alt="leave 이미지" width={300} height={300} />
+      </div>
+      <FixedButton variant="error" onClick={() => withdraw()}>
+        탈퇴하기
+      </FixedButton>
+    </div>
+  );
+};
+
+export default MpaDeletePage;

--- a/src/app/(mpa)/mpa/delete/page.tsx
+++ b/src/app/(mpa)/mpa/delete/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { captureException } from '@sentry/nextjs';
 import { FunnelHeadline } from '@/app/(funnel)/components';
 import { FixedButton } from '@/components/ui';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
@@ -31,7 +32,10 @@ const DeleteContent = () => {
       await clearAuth();
       window.location.replace('/');
     } catch (err) {
-      alert(err instanceof Error ? err.message : '탈퇴 중 오류가 발생했습니다.');
+      // 원인은 Sentry 로 추적하고(앱 표준 에러 트래킹), 사용자에겐 raw 에러 대신 일반화된 안내만 노출한다.
+      // (앱에 공용 toast 시스템이 없어 웹 /delete 와 동일하게 alert 사용)
+      captureException(err);
+      alert('탈퇴 중 오류가 발생했어요.\n잠시 후 다시 시도해주세요.');
     }
   };
 

--- a/src/app/(mpa)/mpa/delete/page.tsx
+++ b/src/app/(mpa)/mpa/delete/page.tsx
@@ -3,31 +3,70 @@
 import Image from 'next/image';
 import { FunnelHeadline } from '@/app/(funnel)/components';
 import { FixedButton } from '@/components/ui';
-import { withdraw } from '@/lib/webview';
+import { useAuth } from '@/features/auth/contexts/AuthContext';
+import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
+import { useDeleteUserMutation } from '@/features/user/apis/queries/useDeleteUserMutation';
+import { isInWebView, withdraw } from '@/lib/webview';
+import AsyncBoundary from '@/shared/components/AsyncBoundary';
 // 웹 /delete 와 동일한 확인 화면 레이아웃을 재사용한다.
 import styles from '@/app/(setting)/delete/page.module.scss';
 
-/**
- * MPA 탈퇴 확인 페이지.
- * /mpa/me 의 '탈퇴하기' 가 (네이티브 팝업/직접 bridge 가 아니라) 이 페이지로 이동하고,
- * 여기서 '탈퇴하기' 버튼을 누르면 'withdraw' 브릿지 이벤트를 송출한다. 실제 탈퇴 처리는 네이티브가 수행한다.
- */
-const MpaDeletePage = () => {
+const DeleteContent = () => {
+  const mutation = useDeleteUserMutation();
+  const { data: profile } = useProfileQuery();
+  const { clearAuth } = useAuth();
+
+  const handleDelete = async () => {
+    try {
+      // 실제 백엔드 탈퇴 (DELETE /api/users/delete)
+      await mutation.mutateAsync();
+      // 웹뷰면 네이티브에 탈퇴 완료를 통지해 후처리(웹뷰 dismiss·로그아웃)를 위임한다. withdraw() 의 반환값은
+      // postMessage '전달' 성공일 뿐 네이티브의 dismiss 를 보장하지 않으므로, 이를 dismiss 증거로 신뢰하지 않는다.
+      if (isInWebView()) {
+        withdraw();
+      }
+      // 네이티브 dismiss 여부와 무관하게 항상 세션 + 인메모리 토큰 + React Query 캐시를 폐기하고 랜딩으로
+      // hard navigate 한다. 이렇게 해야 dismiss 실패 시에도 탈퇴된 계정 화면에 유효 세션이 남지 않고,
+      // 즉시 이동(replace)으로 버튼 재탭(중복 탈퇴 호출)도 차단된다. (웹 /delete 의 안전 패턴과 동일)
+      await clearAuth();
+      window.location.replace('/');
+    } catch (err) {
+      alert(err instanceof Error ? err.message : '탈퇴 중 오류가 발생했습니다.');
+    }
+  };
+
   return (
     <div className={styles.container}>
       <div className="gap-14" />
       <FunnelHeadline
-        title="척척학사를<br/>떠나시겠어요?"
+        title={`${profile.name}님 <br/>척척학사를 떠나시겠어요?`}
+        highlightText={profile.name}
         description="다음 패치가 있기 전까지 재가입이 불가능합니다.<br/>척척학사에서 수집하는 개인 정보는<br/>탈퇴 즉시 폐기됩니다."
       />
       <div className={styles.imageWrapper}>
         <Image src="/images/illustrations/Leave.png" alt="leave 이미지" width={300} height={300} />
       </div>
-      <FixedButton variant="error" onClick={() => withdraw()}>
+      <FixedButton
+        variant="error"
+        onClick={handleDelete}
+        disabled={mutation.isPending}
+        isLoading={mutation.isPending}
+      >
         탈퇴하기
       </FixedButton>
     </div>
   );
 };
+
+/**
+ * MPA 탈퇴 확인 페이지.
+ * /mpa/me '탈퇴하기' → 이 페이지로 이동(네이티브 팝업/직접 bridge 대체).
+ * 버튼 → 실제 백엔드 탈퇴 + 세션 정리 후, 웹뷰면 'withdraw' 브릿지로 네이티브에 후처리 위임(웹은 / 이동).
+ */
+const MpaDeletePage = () => (
+  <AsyncBoundary>
+    <DeleteContent />
+  </AsyncBoundary>
+);
 
 export default MpaDeletePage;

--- a/src/app/(mpa)/mpa/me/page.tsx
+++ b/src/app/(mpa)/mpa/me/page.tsx
@@ -2,15 +2,19 @@
 
 import { Icon } from '@/components/ui';
 import { Menu } from '@/components/ui/Menu';
-import { withdraw } from '@/lib/webview';
+import { ROUTES } from '@/constants/routes';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
 
 const MpaMePage = () => {
+  const router = useInternalRouter();
+
   const menuItems = [
     {
       label: '탈퇴하기',
       color: '#FF5751',
       icon: <Icon name="arrow-right" size={24} />,
-      onClick: () => withdraw(),
+      // 네이티브 팝업/직접 bridge 대신 /mpa/delete 확인 페이지로 이동. 실제 탈퇴(withdraw 브릿지)는 그 페이지 버튼에서.
+      onClick: () => router.push(ROUTES.MPA.DELETE),
     },
   ];
 

--- a/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 // /mpa/resync/scraping 과 동일 흐름. portal-login entry point 의 후행 페이지. 프로토콜: docs/mpa-school-link-handoff.md
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
-import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
+import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
 import { EVENTS, useTrackView } from '@/lib/analytics';
@@ -36,15 +36,23 @@ export default function MpaPortalLoginScrapingPage() {
   const jobStatus = jobStatusData?.status;
   const jobDetail = jobStatusData;
 
+  // 3분 타임아웃 직후 마지막 폴링을 놓친 경우, summary 로 실제 성공 여부를 한 번 더 확인한다.
+  const summaryQuery = usePortalLinkSummary(jobId, isTimedOut);
+  const summaryData = summaryQuery.data;
+  // 폴링 succeeded 거나, 타임아웃 후 summary 가 succeeded 면 성공으로 처리한다.
+  const isSucceeded = jobStatus === 'succeeded' || summaryData?.status === 'succeeded';
+  const succeededRef = useRef(false);
+
   const clearJobId = useCallback(() => {
     sessionStorage.removeItem(PORTAL_LOGIN_JOB_ID_KEY);
     setJobId(null);
   }, []);
 
   useEffect(() => {
-    if (jobStatus !== 'succeeded') {
+    if (succeededRef.current || !isSucceeded) {
       return;
     }
+    succeededRef.current = true;
     // 성공 시엔 jobId state 를 null 로 만들지 않음. 그러면 아래 MISSING_JOB_MESSAGE 가드가
     // 잘못 트리거되어 webview bridge 송출 직후(=native dismiss 전) "연동 정보를 찾을 수 없어요"
     // 화면이 표출됨. 폴링은 'succeeded' 시 refetchInterval 에서 자동 정지하므로 state 유지해도 안전.
@@ -60,12 +68,16 @@ export default function MpaPortalLoginScrapingPage() {
     } else {
       router.push(ROUTES.MAIN);
     }
-  }, [jobStatus, router]);
+  }, [isSucceeded, router]);
 
   const { failureMessage } = usePortalLinkFailure({
     jobStatus,
     jobDetail,
     isTimedOut,
+    summaryResolved: summaryQuery.isFetched,
+    // 성공 판정(isSucceeded)과 동일 신호로 맞춰, 성공이 확정되면 타임아웃 실패가 절대 안 뜨게 한다.
+    // (마지막 폴링 succeeded 가 타임아웃 직전 도착하는 race 에서도 실패가 끼어들지 않도록)
+    recovered: isSucceeded,
     loginRoute: ROUTES.MPA.PORTAL_LOGIN,
     onCleanup: clearJobId,
   });
@@ -74,19 +86,21 @@ export default function MpaPortalLoginScrapingPage() {
     router.push(ROUTES.MPA.PORTAL_LOGIN);
   };
 
-  if (isJobIdResolved && !jobId) {
+  // failureMessage 를 MISSING 가드보다 먼저 본다. 실패 처리(onCleanup)가 jobId 를 null 로 만들어도
+  // 타임아웃/부적격/시스템 실패 메시지가 "연동 정보를 찾을 수 없어요" 로 가려지지 않도록.
+  if (failureMessage) {
     return (
       <div className={errorStyles.container}>
-        <ErrorScreen errorMessage={MISSING_JOB_MESSAGE} />
+        <ErrorScreen errorMessage={failureMessage} />
         <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
       </div>
     );
   }
 
-  if (failureMessage) {
+  if (isJobIdResolved && !jobId) {
     return (
       <div className={errorStyles.container}>
-        <ErrorScreen errorMessage={failureMessage} />
+        <ErrorScreen errorMessage={MISSING_JOB_MESSAGE} />
         <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
       </div>
     );

--- a/src/app/(mpa)/mpa/resync/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/resync/scraping/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
-import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
+import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
 import { EVENTS, track, useTrackView } from '@/lib/analytics';
@@ -35,15 +35,23 @@ export default function MpaScrapingPage() {
   const jobStatus = jobStatusData?.status;
   const jobDetail = jobStatusData;
 
+  // 3분 타임아웃 직후 마지막 폴링을 놓친 경우, summary 로 실제 성공 여부를 한 번 더 확인한다.
+  const summaryQuery = usePortalLinkSummary(jobId, isTimedOut);
+  const summaryData = summaryQuery.data;
+  // 폴링 succeeded 거나, 타임아웃 후 summary 가 succeeded 면 성공으로 처리한다.
+  const isSucceeded = jobStatus === 'succeeded' || summaryData?.status === 'succeeded';
+  const succeededRef = useRef(false);
+
   const clearJobId = useCallback(() => {
     sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
     setJobId(null);
   }, []);
 
   useEffect(() => {
-    if (jobStatus !== 'succeeded') {
+    if (succeededRef.current || !isSucceeded) {
       return;
     }
+    succeededRef.current = true;
     // 성공 시엔 jobId state 를 null 로 만들지 않음. 그러면 아래 MISSING_JOB_MESSAGE 가드가
     // 잘못 트리거되어 webview bridge 송출 직후(=native dismiss 전) "연동 정보를 찾을 수 없어요"
     // 화면이 표출됨. 폴링은 'succeeded' 시 refetchInterval 에서 자동 정지하므로 state 유지해도 안전.
@@ -51,16 +59,25 @@ export default function MpaScrapingPage() {
     clearRetry();
     track(EVENTS.UNIV_RESYNC_COMPLETE);
     if (isInWebView()) {
-      postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+      const posted = postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+      if (!posted) {
+        // 브리지 송출 실패(race/예외) 시 LoadingScreen 에 멈추지 않도록 fallback 이동.
+        // (특히 타임아웃 회복 성공 경로가 이 블록을 타므로 fallback 이 없으면 사용자가 갇힘)
+        router.push(ROUTES.MAIN);
+      }
     } else {
       router.push(ROUTES.MAIN);
     }
-  }, [jobStatus, router]);
+  }, [isSucceeded, router]);
 
   const { failureMessage } = usePortalLinkFailure({
     jobStatus,
     jobDetail,
     isTimedOut,
+    summaryResolved: summaryQuery.isFetched,
+    // 성공 판정(isSucceeded)과 동일 신호로 맞춰, 성공이 확정되면 타임아웃 실패가 절대 안 뜨게 한다.
+    // (마지막 폴링 succeeded 가 타임아웃 직전 도착하는 race 에서도 실패가 끼어들지 않도록)
+    recovered: isSucceeded,
     loginRoute: ROUTES.MPA.RESYNC_LOGIN,
     onCleanup: clearJobId,
   });
@@ -69,19 +86,21 @@ export default function MpaScrapingPage() {
     router.push(ROUTES.MPA.RESYNC_LOGIN);
   };
 
-  if (isJobIdResolved && !jobId) {
+  // failureMessage 를 MISSING 가드보다 먼저 본다. 실패 처리(onCleanup)가 jobId 를 null 로 만들어도
+  // 타임아웃/부적격/시스템 실패 메시지가 "연동 정보를 찾을 수 없어요" 로 가려지지 않도록.
+  if (failureMessage) {
     return (
       <div className={errorStyles.container}>
-        <ErrorScreen errorMessage={MISSING_JOB_MESSAGE} />
+        <ErrorScreen errorMessage={failureMessage} />
         <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
       </div>
     );
   }
 
-  if (failureMessage) {
+  if (isJobIdResolved && !jobId) {
     return (
       <div className={errorStyles.container}>
-        <ErrorScreen errorMessage={failureMessage} />
+        <ErrorScreen errorMessage={MISSING_JOB_MESSAGE} />
         <FixedButton onClick={handleRetry}>다시 시도하기</FixedButton>
       </div>
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { AnalyticsProvider } from '@/lib/analytics';
 import { RemoteConfigProvider } from '@/lib/remote-config';
 import MaintenancePage from '@/components/MaintenancePage';
 import { GlobalErrorReporter } from '@/lib/error-reporting';
+import NotifyRenderedToNative from '@/lib/webview/NotifyRenderedToNative';
 import '../styles/global.scss';
 
 export const metadata: Metadata = {
@@ -81,6 +82,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
           </AuthProvider>
         )}
         <GlobalErrorReporter />
+        <NotifyRenderedToNative />
         <Analytics />
         {/* Cloudflare Web Analytics: 스크립트 삽입 */}
         <Script

--- a/src/app/resync/scraping/page.tsx
+++ b/src/app/resync/scraping/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
-import { usePortalLinkFailure, usePortalLinkJobPolling } from '@/features/portal-link/hooks';
+import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
 import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
 import { EVENTS, track, useTrackView } from '@/lib/analytics';
@@ -30,27 +30,40 @@ export default function ScrapingPage() {
   const jobStatus = jobStatusData?.status;
   const jobDetail = jobStatusData;
 
+  // 3분 타임아웃 직후 마지막 폴링을 놓친 경우, summary 로 실제 성공 여부를 한 번 더 확인한다.
+  const summaryQuery = usePortalLinkSummary(jobId, isTimedOut);
+  const summaryData = summaryQuery.data;
+  // 폴링 succeeded 거나, 타임아웃 후 summary 가 succeeded 면 성공으로 처리한다.
+  const isSucceeded = jobStatus === 'succeeded' || summaryData?.status === 'succeeded';
+  const succeededRef = useRef(false);
+
   const clearJobId = useCallback(() => {
     sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
     setJobId(null);
   }, []);
 
   useEffect(() => {
-    if (jobStatus === 'succeeded') {
-      // 성공 시엔 jobId state 를 null 로 만들지 않음. setJobId(null) + router.push 가
-      // 같은 tick 에 배치되면 unmount 전 재렌더에서 MISSING_JOB_MESSAGE 가 깜빡일 수 있음.
-      // 폴링은 'succeeded' 시 refetchInterval 에서 자동 정지하므로 state 유지해도 안전.
-      sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
-      clearRetry();
-      track(EVENTS.UNIV_RESYNC_COMPLETE);
-      router.push(ROUTES.MAIN);
+    if (succeededRef.current || !isSucceeded) {
+      return;
     }
-  }, [jobStatus, router]);
+    succeededRef.current = true;
+    // 성공 시엔 jobId state 를 null 로 만들지 않음. setJobId(null) + router.push 가
+    // 같은 tick 에 배치되면 unmount 전 재렌더에서 MISSING_JOB_MESSAGE 가 깜빡일 수 있음.
+    // 폴링은 'succeeded' 시 refetchInterval 에서 자동 정지하므로 state 유지해도 안전.
+    sessionStorage.removeItem(RESYNC_JOB_ID_KEY);
+    clearRetry();
+    track(EVENTS.UNIV_RESYNC_COMPLETE);
+    router.push(ROUTES.MAIN);
+  }, [isSucceeded, router]);
 
   const { failureMessage } = usePortalLinkFailure({
     jobStatus,
     jobDetail,
     isTimedOut,
+    summaryResolved: summaryQuery.isFetched,
+    // 성공 판정(isSucceeded)과 동일 신호로 맞춰, 성공이 확정되면 타임아웃 실패가 절대 안 뜨게 한다.
+    // (마지막 폴링 succeeded 가 타임아웃 직전 도착하는 race 에서도 실패가 끼어들지 않도록)
+    recovered: isSucceeded,
     loginRoute: ROUTES.RESYNC.LOGIN,
     onCleanup: clearJobId,
   });

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -19,11 +19,10 @@ export const ROUTES = {
   GRADUATION_PROGRESS: '/graduation-progress',
   SETTING: '/setting',
   DELETE: '/delete',
-  // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트.
-  // HOME/ME, GRADUATION_PROGRESS, RESYNC_LOGIN/RESYNC_SCRAPING, PORTAL_LOGIN/PORTAL_LOGIN_SCRAPING
-  // 은 Next.js 페이지로 실재하며 네이티브가 webview 로 직접 로드한다.
-  // DELETE 는 Next.js 페이지가 없는 JS bridge dispatch key 로, navigateNative()
-  // 송출 시 네이티브가 자체 화면/액션으로 해석한다.
+  // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트로, 전부 Next.js 페이지로 실재하며
+  // 네이티브가 webview 로 직접 로드한다. (HOME/ME, GRADUATION_PROGRESS,
+  // RESYNC_LOGIN/RESYNC_SCRAPING, PORTAL_LOGIN/PORTAL_LOGIN_SCRAPING, DELETE)
+  // DELETE 는 탈퇴 확인 페이지로, 버튼이 'withdraw' 브릿지 이벤트를 송출해 실제 탈퇴는 네이티브가 수행한다.
   MPA: {
     HOME: '/mpa/home',
     ME: '/mpa/me',

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -22,7 +22,9 @@ export const ROUTES = {
   // /mpa/* 는 네이티브 앱이 WebView로 임베드하는 라우트로, 전부 Next.js 페이지로 실재하며
   // 네이티브가 webview 로 직접 로드한다. (HOME/ME, GRADUATION_PROGRESS,
   // RESYNC_LOGIN/RESYNC_SCRAPING, PORTAL_LOGIN/PORTAL_LOGIN_SCRAPING, DELETE)
-  // DELETE 는 탈퇴 확인 페이지로, 버튼이 'withdraw' 브릿지 이벤트를 송출해 실제 탈퇴는 네이티브가 수행한다.
+  // DELETE 는 탈퇴 확인 페이지. 버튼이 웹에서 실제 백엔드 탈퇴(DELETE /api/users/delete)를 수행한 뒤
+  // 'withdraw' 브릿지로 네이티브에 '탈퇴 완료'를 통지하면, 네이티브가 웹뷰 dismiss·로그아웃 후처리를 한다.
+  // (삭제는 웹이 1회만 수행 — 네이티브가 다시 DELETE 를 호출하지 않도록 한다.)
   MPA: {
     HOME: '/mpa/home',
     ME: '/mpa/me',

--- a/src/features/portal-link/hooks/usePortalLinkFailure.ts
+++ b/src/features/portal-link/hooks/usePortalLinkFailure.ts
@@ -9,6 +9,13 @@ interface UsePortalLinkFailureParams {
   jobStatus?: string;
   jobDetail?: JobStatusResponse;
   isTimedOut: boolean;
+  /**
+   * 타임아웃 시 summary 재확인이 끝났는지 여부. true 가 되기 전엔 타임아웃을 실패로 확정하지 않고
+   * 로딩을 유지한다. 기본 true — summary 회복을 쓰지 않는 호출부는 기존(즉시 실패) 동작 유지.
+   */
+  summaryResolved?: boolean;
+  /** 타임아웃이지만 summary 로 실제 성공이 확인됨 — 실패 처리하지 않는다(성공 핸들러가 처리). */
+  recovered?: boolean;
   /** 자격증명 실패 시 복귀할 로그인 라우트. */
   loginRoute: RoutePath;
   /** 실패 처리 직전 정리 (예: sessionStorage jobId 제거). */
@@ -27,6 +34,8 @@ export function usePortalLinkFailure({
   jobStatus,
   jobDetail,
   isTimedOut,
+  summaryResolved = true,
+  recovered = false,
   loginRoute,
   onCleanup,
 }: UsePortalLinkFailureParams) {
@@ -60,13 +69,15 @@ export function usePortalLinkFailure({
     if (handledRef.current) {
       return;
     }
-    if (isTimedOut) {
+    // 타임아웃이어도 summary 재확인이 끝나기 전(summaryResolved=false)엔 실패로 확정하지 않는다.
+    // summary 가 성공을 확인하면(recovered) 성공 핸들러가 처리하므로 여기선 실패 처리하지 않는다.
+    if (isTimedOut && summaryResolved && !recovered) {
       handledRef.current = true;
       onCleanup?.();
       captureException(new Error('[portal-link] timeout'));
       setFailureMessage(TIMEOUT_ERROR_MESSAGE);
     }
-  }, [isTimedOut, onCleanup]);
+  }, [isTimedOut, summaryResolved, recovered, onCleanup]);
 
   return { failureMessage };
 }

--- a/src/features/portal-link/hooks/usePortalLinkSummary.ts
+++ b/src/features/portal-link/hooks/usePortalLinkSummary.ts
@@ -1,7 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { getJobSummary } from '../services/portalLinkService';
 
-export function usePortalLinkSummary(jobId: string | null, jobStatus: string | undefined) {
+/**
+ * 포털 연동 job 의 summary(studentInfo·status)를 조회한다.
+ *
+ * 호출부가 `enabled` 로 조회 시점을 직접 정한다:
+ * - funnel: 폴링이 succeeded 일 때(studentInfo 확보) + 타임아웃 회복 확인
+ * - resync/portal-login: 3분 타임아웃 회복 확인 전용
+ *
+ * 타임아웃 직후 마지막 폴링을 놓쳐 succeeded 를 못 받은 경우, 이 조회의 status/studentInfo 로
+ * 실제 성공 여부를 한 번 더 확인해 false-timeout 을 구제한다. (jobId 는 타임아웃 후에도 유효)
+ */
+export function usePortalLinkSummary(jobId: string | null, enabled: boolean) {
   return useQuery({
     queryKey: ['portal-link-summary', jobId],
     queryFn: () => {
@@ -10,6 +20,6 @@ export function usePortalLinkSummary(jobId: string | null, jobStatus: string | u
       }
       return getJobSummary(jobId);
     },
-    enabled: Boolean(jobId) && jobStatus === 'succeeded',
+    enabled: Boolean(jobId) && enabled,
   });
 }

--- a/src/lib/webview/NotifyRenderedToNative.tsx
+++ b/src/lib/webview/NotifyRenderedToNative.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { notifyRendered } from './bridge';
+
+/**
+ * 웹뷰 초기 로딩 시 빈 화면 노출을 줄이기 위한 컴포넌트.
+ *
+ * 네이티브가 onPageFinished(HTML 파싱 완료)에 로더를 내리면 CSR 렌더 전이라 빈 화면이 보인다.
+ * 대신 웹이 첫 페인트 직후 'rendered' 브릿지를 송출하고, 네이티브가 그 신호에 로더/스플래시를 내리도록 한다.
+ *
+ * requestAnimationFrame 을 2회 중첩해 (커밋 → 다음 프레임 직전 → 그 다음 프레임) 실제 페인트가 끝난 뒤
+ * 송출되도록 한다. 웹뷰가 아니면 postBridgeMessage 가 no-op 이라 일반 웹에는 영향이 없다.
+ * 루트에 두어 웹뷰로 로드되는 모든 라우트(MPA·funnel)의 초기 로드 시 1회 송출된다.
+ */
+const NotifyRenderedToNative = () => {
+  useEffect(() => {
+    let innerRaf = 0;
+    const outerRaf = requestAnimationFrame(() => {
+      innerRaf = requestAnimationFrame(() => {
+        notifyRendered();
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(outerRaf);
+      cancelAnimationFrame(innerRaf);
+    };
+  }, []);
+
+  return null;
+};
+
+export default NotifyRenderedToNative;

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -81,8 +81,8 @@ export const redirectToHome = (): boolean => {
   return postBridgeMessage('redirectToHome');
 };
 
-// /mpa/me 의 '탈퇴하기' → 네이티브에 계정 탈퇴 플로우 진입을 위임한다. 네이티브가 탈퇴 확인/처리
-// 화면을 자체적으로 띄운다 (웹뷰는 라우팅하지 않음). 기존 navigate:/mpa/delete dispatch 를 대체.
+// /mpa/delete 확인 페이지의 '탈퇴하기' 버튼 → 네이티브에 계정 탈퇴 처리를 위임한다.
+// (/mpa/me '탈퇴하기' 는 이 확인 페이지로 이동하고, 페이지 버튼이 이 이벤트를 송출한다.)
 export const withdraw = (): boolean => {
   return postBridgeMessage('withdraw');
 };

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -86,3 +86,10 @@ export const redirectToHome = (): boolean => {
 export const withdraw = (): boolean => {
   return postBridgeMessage('withdraw');
 };
+
+// 웹뷰 초기 로딩 시 첫 페인트 직후 네이티브에 렌더 완료를 통지한다. 네이티브는 onPageFinished
+// (HTML 파싱 완료)가 아니라 이 신호에 로더/스플래시를 내려야, CSR 렌더 전까지의 빈 화면 노출이 줄어든다.
+// 송출 시점은 requestAnimationFrame 으로 실제 페인트 이후가 되도록 호출부에서 보장한다.
+export const notifyRendered = (): boolean => {
+  return postBridgeMessage('rendered');
+};

--- a/src/lib/webview/bridge.ts
+++ b/src/lib/webview/bridge.ts
@@ -81,8 +81,9 @@ export const redirectToHome = (): boolean => {
   return postBridgeMessage('redirectToHome');
 };
 
-// /mpa/delete 확인 페이지의 '탈퇴하기' 버튼 → 네이티브에 계정 탈퇴 처리를 위임한다.
-// (/mpa/me '탈퇴하기' 는 이 확인 페이지로 이동하고, 페이지 버튼이 이 이벤트를 송출한다.)
+// /mpa/delete 확인 페이지의 '탈퇴하기' 버튼은 웹에서 실제 백엔드 탈퇴(DELETE /api/users/delete)를
+// 수행한 뒤, 이 'withdraw' 로 네이티브에 '탈퇴 완료'를 통지한다(삭제를 네이티브에 위임하는 게 아님).
+// 네이티브는 이 신호에 웹뷰 dismiss·로그아웃 후처리만 하고, DELETE 를 다시 호출하지 않는다(중복 탈퇴 방지).
 export const withdraw = (): boolean => {
   return postBridgeMessage('withdraw');
 };

--- a/src/lib/webview/index.ts
+++ b/src/lib/webview/index.ts
@@ -1,1 +1,9 @@
-export { isInWebView, postBridgeMessage, navigateNative, navigateBack, redirectToHome, withdraw } from './bridge';
+export {
+  isInWebView,
+  postBridgeMessage,
+  navigateNative,
+  navigateBack,
+  redirectToHome,
+  withdraw,
+  notifyRendered,
+} from './bridge';


### PR DESCRIPTION
## 요약
수원대 학사 앱 웹뷰(MPA) UX 개선 묶음 (6 commits). 대응 웹 화면과 동작·여백을 맞추고 초기 빈 화면을 줄였습니다.

## 변경 사항
- **fix(portal-link): 3분 타임아웃 false-failure 구제** — 폴링 타임아웃 시 곧장 실패시키지 않고 getJobSummary 로 실제 성공 여부를 재확인(succeeded면 정상 성공, 아니면 기존 타임아웃 실패). MPA 스크래핑 렌더 가드 순서를 failure→MISSING 으로 교체(실패 메시지가 "연동 정보를 찾을 수 없어요"로 가려지던 버그 수정). recovered 를 성공 신호와 정렬해 success/timeout race 제거.
- **fix(mpa): 재연동 실패 시 `<` → 홈** — /mpa/resync/login 의 뒤로가기가 router.back()(jobId 비워진 stale scraping 트랩) 대신 홈으로(webview: redirectToHome / web: /mpa/home, 브리지 실패 fallback).
- **fix(loading): 가짜 홈 인디케이터 웹뷰 숨김** — LoadingScreen 하단 장식 인디케이터를 웹뷰에선 숨김(OS 실제 인디케이터와 중복 제거). 일반 웹은 유지.
- **feat(mpa): 탈퇴 → /mpa/delete 페이지 + 실제 백엔드 탈퇴 + 이름 개인화** — /mpa/me 탈퇴하기가 네이티브 팝업 대신 /mpa/delete 확인 페이지로 이동. 버튼이 실제 DELETE /api/users/delete 수행 + 이름 개인화. 성공 후 웹뷰면 withdraw 브릿지로 통지하되 항상 clearAuth+이동으로 dismiss 실패 시 stale 세션/중복 탈퇴 차단.
- **fix(mpa): 여백 정합** — (mpa) 레이아웃이 모든 라우트에 동일 패딩을 적용해 웹과 어긋나던 것을 라우트별 분기. graduation 이중 패딩(40→20px) 제거, delete 추가 하단 여백 제거.
- **feat(webview): 'rendered' 신호로 초기 빈 화면 단축** — 첫 페인트 직후(rAF 2회) postBridgeMessage('rendered') 송출.

## ⚠️ 네이티브 협의 필요
1. **withdraw 의미 재정의**: 이제 웹이 실제 삭제를 수행 → 네이티브는 withdraw 수신 시 "삭제 수행"이 아니라 "삭제 완료 → 웹뷰 dismiss/로그아웃"으로 처리(중복 DELETE 방지).
2. **rendered 핸들러 등록**: 로더를 onPageFinished 가 아니라 'rendered' 메시지에 내리도록. 미수신 대비 타임아웃 fallback 권장.
3. **redirectToHome**: resync 실패 < 가 이 브릿지 사용(이미 portal-login opt-out 에서 사용 중).

## QA 체크
- 여백 2쌍 시각 확인: /mpa/delete↔/delete, /mpa/graduation-progress↔/graduation-progress
- 타임아웃 경계에서 success/timeout 동시 발화 없는지
- 탈퇴: 네이티브 dismiss 실패 시 fallback(clearAuth + /) 동작
- /mpa/delete 진입 전 네이티브 확인 단계 존재 여부 (web 의 confirm() 은 제거)

## 알려진 별도 이슈 (이 PR 범위 밖, 후속 PR)
useProfileQuery 가 reconnectionRequired 시 웹 전용 /resync/login 으로 보내 웹뷰에서 웹 플로우로 빠지는 기존 이슈 → 별도 브랜치/PR 로 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계정 탈퇴 확인 페이지 추가
  * 웹뷰 환경에서 초기 렌더링 완료 신호 송출

* **버그 수정**
  * 포털 연동 완료 감지 개선 (타임아웃 상황 포함)
  * 웹뷰 환경에서의 홈 이동 처리 개선

* **개선**
  * 웹뷰 환경에 맞춘 UI 요소 숨김 처리
  * 콘텐츠 영역 스크롤 레이아웃 옵션 확대
  * 탈퇴하기 메뉴를 확인 페이지로 이동하도록 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->