### PR TITLE
fix(mpa): route reconnection redirect to MPA resync login inside webview

### DIFF
--- a/src/features/dashboard/apis/queries/useProfileQuery.ts
+++ b/src/features/dashboard/apis/queries/useProfileQuery.ts
@@ -1,6 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { ROUTES } from '@/constants';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { isInWebView } from '@/lib/webview';
 import { studentApi } from '@/shared/api/client';
 import type { StudentProfileApiResponse } from '@/shared/api/data-contracts';
 import { ApiResponseHandler } from '@/shared/api/utils/response-handler';
@@ -19,7 +20,9 @@ export function useProfileQuery() {
       const profile = StudentProfileSchema.parse(response.data);
 
       if (profile.reconnectionRequired) {
-        router.push(ROUTES.RESYNC.LOGIN);
+        // 웹뷰(MPA)에선 MPA 재연동 라우트로 보내야 한다. 웹 전용 /resync/login 으로 보내면 웹뷰 안에서
+        // 웹 재연동 플로우로 빠져 done:portal-link 브릿지가 끊긴다. (웹은 기존대로 /resync/login)
+        router.push(isInWebView() ? ROUTES.MPA.RESYNC_LOGIN : ROUTES.RESYNC.LOGIN);
       }
       return profile;
     },


### PR DESCRIPTION
## 문제
`useProfileQuery`(공유 훅)가 `reconnectionRequired`(포털 세션 만료 → 재연동 필요) 시 **항상 웹 전용 `/resync/login`** 으로 push 한다(`useProfileQuery.ts:21-23`). 웹뷰(MPA)에서도 같은 웹 라우트로 보내므로:
- 사용자가 **웹뷰 안에서 웹 재연동 플로우**(`/resync/login → /resync/scraping → /main`)로 빠짐.
- 성공해도 **`done:portal-link` 브릿지 미송출** → 네이티브가 연동 완료를 모르고 웹뷰 dismiss/갱신이 안 됨.
- 네이티브 헤더/뒤로가기와 어긋남.

`reconnectionRequired`는 포털 세션 만료 때마다 발생하는 **반복 상태**라 엣지가 아님. 영향 범위: 프로필을 쓰는 모든 MPA 화면 — 특히 **`/mpa/home`**(ProfileCard·SyncUpdateButton·UserPropertiesSync·졸업/복수전공 카드)과 `/mpa/delete`.

## 수정
`isInWebView()` 분기로 라우팅 대상을 고친다:
```ts
router.push(isInWebView() ? ROUTES.MPA.RESYNC_LOGIN : ROUTES.RESYNC.LOGIN);
```
- 웹뷰 → `/mpa/resync/login`(정상 MPA 재연동 플로우 → `done:portal-link` 브릿지).
- 웹 → 기존 `/resync/login` 유지.
- 공유 훅 한 곳 수정으로 MPA 전역(home·delete 등) 동시 해결.

## 참고
- 이건 **기존 이슈**(이전부터 하드코딩). 별도 PR #228 작업 중 발견해 분리했습니다.
- `queryFn` 내부 side-effect(렌더 중 redirect) 구조 스멜은 그대로 둠 — 원본 주석대로 "컴포넌트로 추출" 리팩터는 별도 티켓 권장(이번 변경 범위 밖).

## QA
- 웹뷰에서 `reconnectionRequired=true` 강제 시 `/mpa/resync/login`으로 가는지(웹 `/resync/login` 아님) 확인.
- 일반 웹은 기존대로 `/resync/login` 유지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 웹뷰 환경에서 로그인 재동기화 시 올바른 경로로 리다이렉트되도록 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->