### PR TITLE
fix(withdraw): 미연동 유저도 회원탈퇴 가능하도록 수정

### DIFF
--- a/src/app/(mpa)/mpa/delete/page.tsx
+++ b/src/app/(mpa)/mpa/delete/page.tsx
@@ -5,16 +5,24 @@ import { captureException } from '@sentry/nextjs';
 import { FunnelHeadline } from '@/app/(funnel)/components';
 import { FixedButton } from '@/components/ui';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
-import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
+import { useWithdrawDisplayName } from '@/features/dashboard/apis/queries/useWithdrawDisplayName';
 import { useDeleteUserMutation } from '@/features/user/apis/queries/useDeleteUserMutation';
 import { isInWebView, withdraw } from '@/lib/webview';
-import AsyncBoundary from '@/shared/components/AsyncBoundary';
 // 웹 /delete 와 동일한 확인 화면 레이아웃을 재사용한다.
 import styles from '@/app/(setting)/delete/page.module.scss';
 
-const DeleteContent = () => {
+/**
+ * MPA 탈퇴 확인 페이지.
+ * /mpa/me '탈퇴하기' → 이 페이지로 이동(네이티브 팝업/직접 bridge 대체).
+ * 버튼 → 실제 백엔드 탈퇴 + 세션 정리 후, 웹뷰면 'withdraw' 브릿지로 네이티브에 후처리 위임(웹은 / 이동).
+ *
+ * 이름은 인사말 개인화용일 뿐이라 미연동 유저(프로필 없음)도 탈퇴 가능하도록 useWithdrawDisplayName
+ * (비-suspense)으로 옵셔널 조회한다. 과거엔 useProfileQuery(suspense)가 미연동 401/404 로 throw 해
+ * 탈퇴 버튼이 에러화면에 가려졌다.
+ */
+const MpaDeletePage = () => {
   const mutation = useDeleteUserMutation();
-  const { data: profile } = useProfileQuery();
+  const displayName = useWithdrawDisplayName();
   const { clearAuth } = useAuth();
 
   const handleDelete = async () => {
@@ -43,8 +51,8 @@ const DeleteContent = () => {
     <div className={styles.container}>
       <div className="gap-14" />
       <FunnelHeadline
-        title={`${profile.name}님 <br/>척척학사를 떠나시겠어요?`}
-        highlightText={profile.name}
+        title={displayName ? `${displayName}님 <br/>척척학사를 떠나시겠어요?` : '척척학사를 <br/>떠나시겠어요?'}
+        highlightText={displayName}
         description="다음 패치가 있기 전까지 재가입이 불가능합니다.<br/>척척학사에서 수집하는 개인 정보는<br/>탈퇴 즉시 폐기됩니다."
       />
       <div className={styles.imageWrapper}>
@@ -61,16 +69,5 @@ const DeleteContent = () => {
     </div>
   );
 };
-
-/**
- * MPA 탈퇴 확인 페이지.
- * /mpa/me '탈퇴하기' → 이 페이지로 이동(네이티브 팝업/직접 bridge 대체).
- * 버튼 → 실제 백엔드 탈퇴 + 세션 정리 후, 웹뷰면 'withdraw' 브릿지로 네이티브에 후처리 위임(웹은 / 이동).
- */
-const MpaDeletePage = () => (
-  <AsyncBoundary>
-    <DeleteContent />
-  </AsyncBoundary>
-);
 
 export default MpaDeletePage;

--- a/src/app/(setting)/delete/layout.tsx
+++ b/src/app/(setting)/delete/layout.tsx
@@ -9,7 +9,8 @@ import styles from './layout.module.scss';
 export default function FunnelLayout({ children }: PropsWithChildren) {
   const router = useInternalRouter();
   return (
-    <ProtectedRoute requirePortalLinked={true}>
+    // 미연동 유저도 탈퇴 가능해야 하므로 portal-link 게이트를 걸지 않는다(/setting 과 동일 정책).
+    <ProtectedRoute>
       <div className={styles.container}>
         <TopNavigation.Preset title="탈퇴하기" type="back" onNavigationClick={() => router.back()} />
         <div className={styles.content}>{children}</div>

--- a/src/app/(setting)/delete/page.tsx
+++ b/src/app/(setting)/delete/page.tsx
@@ -3,14 +3,15 @@
 import Image from 'next/image';
 import { FunnelHeadline } from '@/app/(funnel)/components';
 import { FixedButton } from '@/components/ui';
-import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
+import { useWithdrawDisplayName } from '@/features/dashboard/apis/queries/useWithdrawDisplayName';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { useDeleteUserMutation } from '@/features/user/apis/queries/useDeleteUserMutation';
 import styles from './page.module.scss';
 
 const DeletePage = () => {
   const mutation = useDeleteUserMutation();
-  const { data: profile } = useProfileQuery();
+  // 이름은 '인사말 개인화'용일 뿐 탈퇴의 필수 조건이 아니다. 미연동 유저는 프로필이 없어 undefined.
+  const displayName = useWithdrawDisplayName();
   const { clearAuth } = useAuth();
 
   const handleDelete = async () => {
@@ -34,8 +35,8 @@ const DeletePage = () => {
     <div className={styles.container}>
       <div className="gap-14" />
       <FunnelHeadline
-        title={`${profile.name}님 <br/>척척학사를 떠나시겠어요?`}
-        highlightText={profile.name}
+        title={displayName ? `${displayName}님 <br/>척척학사를 떠나시겠어요?` : '척척학사를 <br/>떠나시겠어요?'}
+        highlightText={displayName}
         description="다음 패치가 있기 전까지 재가입이 불가능합니다.<br/>척척학사에서 수집하는 개인 정보는<br/>탈퇴 즉시 폐기됩니다."
       />
       <div className={styles.imageWrapper}>

--- a/src/app/(setting)/setting/layout.tsx
+++ b/src/app/(setting)/setting/layout.tsx
@@ -9,7 +9,9 @@ import styles from './layout.module.scss';
 export default function FunnelLayout({ children }: PropsWithChildren) {
   const router = useInternalRouter();
   return (
-    <ProtectedRoute requirePortalLinked={true}>
+    // 미연동(학교 연동 안 함/탈퇴 후 재로그인) 유저도 탈퇴할 수 있어야 하므로 portal-link 게이트를 걸지 않는다.
+    // 설정 하위는 현재 '탈퇴하기' 단일 메뉴라 미연동 노출에 부작용이 없다(메뉴 추가 시 접근 정책 재검토).
+    <ProtectedRoute>
       <div className={styles.container}>
         <TopNavigation.Preset title="설정" type="back" onNavigationClick={() => router.back()} />
         <div className={styles.content}>{children}</div>

--- a/src/features/dashboard/apis/queries/useWithdrawDisplayName.ts
+++ b/src/features/dashboard/apis/queries/useWithdrawDisplayName.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/features/auth/contexts/AuthContext';
+import { studentApi } from '@/shared/api/client';
+import type { StudentProfileApiResponse } from '@/shared/api/data-contracts';
+import { ApiResponseHandler } from '@/shared/api/utils/response-handler';
+import { dashboardQueryKeys } from '../queryKey';
+import { StudentProfileSchema } from '../schema';
+
+/**
+ * 탈퇴 확인 화면의 인사말 개인화 전용 훅. 연동 유저만 학생 프로필에서 이름을 가져온다.
+ *
+ * useProfileQuery(useSuspenseQuery) 와 의도적으로 다르다:
+ * - 미연동 유저(GET /student/profile 이 401/404)에서도 throw 하지 않아 탈퇴 플로우를 막지 않는다.
+ *   (기존 버그: 표시용 이름 조회 하나가 suspense throw → AsyncBoundary 에러화면 → 탈퇴 불가)
+ * - isPortalLinked === true 일 때만 조회한다(미연동은 애초에 프로필이 없어 401/404 라 네트워크 낭비 방지).
+ * - reconnectionRequired redirect 부수효과가 없다(탈퇴 도중 resync 로 튕기면 안 되므로).
+ *
+ * queryKey 는 dashboardQueryKeys.profile 로 useProfileQuery 와 공유 → 연동 유저는 캐시 적중.
+ * @returns 연동 유저의 이름, 또는 미연동/조회 전이면 undefined.
+ */
+export function useWithdrawDisplayName(): string | undefined {
+  const { isPortalLinked } = useAuth();
+
+  const { data } = useQuery({
+    queryKey: dashboardQueryKeys.profile,
+    queryFn: async () => {
+      const response = await ApiResponseHandler.handleAsyncResponse<StudentProfileApiResponse>(
+        studentApi.getProfile()
+      );
+      return StudentProfileSchema.parse(response.data);
+    },
+    enabled: isPortalLinked === true,
+    retry: false,
+    throwOnError: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return data?.name;
+}


### PR DESCRIPTION
## 문제

포털 **미연동**(학교 연동 안 함 / 탈퇴 후 재로그인) 유저가 회원탈퇴를 할 수 없었습니다.

## 원인

두 탈퇴 페이지가 **'표시용 이름' 하나**를 얻으려고 `useProfileQuery`(`useSuspenseQuery`, `GET /student/profile`)를 호출하는데, 이 API는 미연동 유저에게 **401/404**를 반환 → suspense throw.

- **웹** (`/setting`, `/delete`): `requirePortalLinked` 게이트가 페이지 진입 자체를 차단 (`useAuthCheck` → `/` 리다이렉트)
- **MPA** (`/mpa/delete`): `AsyncBoundary`가 `ApiErrorFallback`(401 시 "세션 만료" 오안내) 렌더 → 탈퇴 버튼 소실

정작 실제 탈퇴(`DELETE /api/users/delete`)는 프로필과 무관한데도 표시용 이름 조회 하나가 전체 탈퇴 플로우를 막았습니다.

## 수정

- **신규 `useWithdrawDisplayName`** 훅: 비-suspense `useQuery`, `isPortalLinked === true`일 때만 조회, `throwOnError:false`/`retry:false`로 **절대 throw 안 함**. 이름은 인사말 개인화용일 뿐이라 미연동은 `undefined` → fallback 문구. `dashboardQueryKeys.profile` 캐시를 `useProfileQuery`와 공유해 연동 유저는 캐시 적중.
- **웹·MPA 두 delete 페이지**: `useProfileQuery` → `useWithdrawDisplayName`로 이름 옵셔널화. MPA는 suspense query가 사라져 불필요해진 `AsyncBoundary`도 제거. 실제 탈퇴 mutation 경로는 **불변**.
- **`(setting)/setting`·`(setting)/delete` 레이아웃**: `requirePortalLinked` 게이트 완화. 설정 하위는 **'탈퇴하기' 단일 메뉴**라 미연동 노출 부작용 없음. `accessToken` 게이트는 유지(익명 유저는 여전히 차단).

## 행동 변화 (의도됨)

`reconnectionRequired`(재연동 필요) 상태인 **연동** 유저가 탈퇴 페이지에서 더 이상 resync로 튕기지 않습니다 — 탈퇴하려는 유저를 재연동으로 보내는 게 부적절하므로 의도된 변경입니다.

## 검증

- `yarn type-check` ✅ / `yarn lint` 0 errors
- 적대적 다중 에이전트 검증: 회귀·보안(익명 접근 차단 유지, 연동 유저 정상 탈퇴 불변) / 정확성·완전성(웹·MPA 두 경로 모두 미연동 탈퇴 가능) — **blocker 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
