### PR TITLE
fix(scraping): iOS에서 연동 로딩 애니메이션·문구가 멈추는 문제 완화

### DIFF
--- a/src/app/(funnel)/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/app/(funnel)/components/LoadingScreen/LoadingScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { captureException } from '@sentry/nextjs';
 import { isInWebView } from '@/lib/webview';
 import styles from './LoadingScreen.module.scss';
 
@@ -19,51 +20,59 @@ const LOADING_STATES = [
   },
 ];
 
+// 안내 문구 순환 간격 / 페이드 전환 시간.
+const TEXT_ROTATE_INTERVAL_MS = 2500;
+const FADE_DURATION_MS = 300;
+
 const LoadingScreen = () => {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const [playCount, setPlayCount] = useState(0);
+  const [stateIndex, setStateIndex] = useState(0);
   const [fadeState, setFadeState] = useState<'in' | 'out'>('in');
   // 웹뷰에선 OS 가 실제 홈 인디케이터를 그리므로 아래 장식용 가짜 인디케이터는 숨긴다.
   // SSR/hydration 불일치(서버엔 window 없음)를 피하려 마운트 후에 판별한다.
   const [isWebView, setIsWebView] = useState(false);
 
+  // 안내 문구 순환 — video 의 'ended' 이벤트가 아니라 독립 타이머로 구동한다.
+  // (iOS WKWebView 는 사용자 제스처 없는 자동재생을 막을 수 있는데, 과거엔 문구 전환이 video.play()→'ended'
+  //  에 종속돼 있어 재생이 거부되면 로고와 함께 문구까지 첫 상태로 얼어붙었다. 텍스트를 비디오와 분리한다.)
+  useEffect(() => {
+    let fadeTimer: ReturnType<typeof setTimeout>;
+    const interval = setInterval(() => {
+      setFadeState('out');
+      fadeTimer = setTimeout(() => {
+        setStateIndex(prev => (prev + 1) % LOADING_STATES.length);
+        setFadeState('in');
+      }, FADE_DURATION_MS);
+    }, TEXT_ROTATE_INTERVAL_MS);
+
+    return () => {
+      clearInterval(interval);
+      clearTimeout(fadeTimer);
+    };
+  }, []);
+
+  // 로고 비디오 자동재생. 마크업의 autoPlay/loop 로 1차 시도하되, 일부 웹뷰는 명시적 play() 가 필요해
+  // 한 번 더 호출한다. iOS 자동재생 정책으로 거부(NotAllowedError)되면 Sentry 로만 추적하고 조용히 넘긴다
+  // — 문구 순환은 위 타이머가 독립적으로 유지하므로 화면이 멈춰 보이지 않는다.
   useEffect(() => {
     const video = videoRef.current;
     if (!video) {
       return;
     }
-
-    const handleEnded = () => {
-      setFadeState('out');
-
-      setTimeout(() => {
-        const nextCount = playCount + 1;
-        setPlayCount(nextCount);
-        setFadeState('in');
-
-        video.play();
-      }, 300);
-    };
-
-    video.addEventListener('ended', handleEnded);
-    video.play();
-
-    return () => {
-      video.removeEventListener('ended', handleEnded);
-    };
-  }, [playCount]);
+    void video.play().catch(captureException);
+  }, []);
 
   useEffect(() => {
     setIsWebView(isInWebView());
   }, []);
 
-  const currentState = LOADING_STATES[playCount % LOADING_STATES.length];
+  const currentState = LOADING_STATES[stateIndex];
 
   return (
     <div className={styles.wrapper}>
       <main className={styles.main}>
         <div className={styles.videoContainer}>
-          <video ref={videoRef} className={styles.video} playsInline muted>
+          <video ref={videoRef} className={styles.video} playsInline muted loop autoPlay preload="auto">
             <source src="/videos/chuck_loading.mp4" type="video/mp4" />
           </video>
         </div>


### PR DESCRIPTION
## 문제

iOS(WKWebView)에서 학교 연동(포털 로그인 → 스크래핑) **로딩 화면의 로고 영상과 안내 문구가 함께 멈춥니다.** (사용자는 Lottie로 추정했으나 실제 구현은 `<video>`)

## 원인

- 로고 애니메이션은 Lottie가 아니라 `<video src="/videos/chuck_loading.mp4">`인데, `autoplay`/`loop` 속성 없이 **JS `video.play()` + `ended` 이벤트에만** 의존.
- 결정적으로 **안내 문구 순환도 `ended`에 종속**(문구 인덱스가 `ended` 핸들러 안에서만 증가).
- iOS는 사용자 제스처 없는 자동재생을 native 설정으로 차단할 수 있는데, 이 화면은 포털 로그인 제출 후 제스처 없이 도달 → `video.play()`가 `NotAllowedError`로 거부되면 `ended`가 영영 오지 않아 **로고와 문구가 함께 첫 상태로 얼어붙음** (거부된 Promise도 미처리).
- 4개 스크래핑 라우트(funnel/MPA portal-login/MPA resync/web resync)가 동일 `LoadingScreen`을 써서 모든 연동 경로에서 재현됩니다.

## 수정 (`LoadingScreen`)

- **안내 문구 순환을 `ended` 의존에서 독립 `setInterval`로 분리** — 영상 재생 성공 여부와 무관하게 문구가 계속 바뀝니다 (언마운트 시 interval/timeout 정리).
- `<video>`에 **`autoPlay`/`loop`/`preload`** 추가로 자동재생을 마크업 차원에서도 시도.
- `video.play()` Promise를 **`.catch`로 처리**해 거부 시 Sentry로 추적하고 조용히 넘김.

이제 iOS에서 영상이 한 프레임도 안 움직여도 **최소한 안내 문구는 계속 순환**해 "멈춘 화면"으로 보이지 않습니다.

## ⚠️ 네이티브 확인 필요 (사용자 쪽 문제일 수 있는 지점)

영상 **자체**가 안 도는 근본 원인은 네이티브 WKWebView 설정일 가능성이 큽니다. iOS 앱 측에서 아래를 확인해 주세요:
- `WKWebViewConfiguration.allowsInlineMediaPlayback = true`
- `mediaTypesRequiringUserActionForPlayback = []` (자동재생 허용)

이 두 설정이 막혀 있으면 `muted + playsInline + autoPlay`라도 거부될 수 있고, 그 경우 **로고 영상 자체는 네이티브 설정 변경이 필요**합니다. 본 PR은 그와 무관하게 프론트에서 할 수 있는 방어(문구는 항상 순환 + play 예외 처리)입니다. 진단은 Safari 원격 디버깅으로 `video.play()`가 reject되는지 확인하면 확정됩니다.

## 검증

- `yarn type-check` ✅ / `yarn lint` 0 errors
- asset 자체는 정상(H.264 / faststart / 404 아님) 확인 — 코덱·경로 문제 아님

🤖 Generated with [Claude Code](https://claude.com/claude-code)
