### PR TITLE
fix(api): iOS WKWebView stale-connection TypeError에 backoff + bounded 재시도

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -51,6 +51,10 @@ export const createApiClient = <T extends new (...args: any) => any>(ApiClass: T
           }
 
           // 예상치 못한 에러 (ex: 네트워크 오류, JSON 파싱 오류 등)
+          // 주의: 여기서 status=500 은 클라이언트가 합성한 값이다(서버 응답이 아예 없었음).
+          // iOS WKWebView 의 `TypeError: Load failed`(전송 계층 실패)도 이 경로로 들어와 500 으로
+          // 표면화되므로, 사용자가 보는 "500"이 곧 백엔드 5xx 를 뜻하지 않는다 — 전송 실패는
+          // httpConfig.ts 의 fetchWithStaleConnRetry 에서 완화한다.
           console.error('API 호출 중 예외 발생:', error);
           throw new ApiError(
             error instanceof Error ? error.message : '네트워크 오류가 발생했습니다',

--- a/src/shared/api/configs/httpConfig.ts
+++ b/src/shared/api/configs/httpConfig.ts
@@ -8,23 +8,59 @@ const BASE_URL = getApiBaseUrl();
 // iOS WKWebView 가 connection pool 에 남은 죽은 connection 을 재사용할 때 즉시 TCP RST 를
 // 받아 `TypeError: Load failed` 를 ~10ms 만에 throw 하는 케이스가 관측됨 (Sentry CCHAKSA-56).
 // AWS API Gateway 처럼 짧은 idle timeout 을 가진 백엔드에서 흔하고, Chromium 은 자체 retry
-// 로 가려지지만 WebKit 은 노출됨. 한 번 재시도하면 새 connection 이 만들어져 풀의 stale
-// entry 를 우회 → 일시적 NETWORK_ERROR 회복. 두 번째도 throw 면 진짜 망 문제로 보고 propagate.
-async function fetchWithStaleConnRetry(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-  // POST/PATCH/DELETE 등 비멱등 메서드는 재시도 금지 — 첫 요청이 서버에 반영된 뒤 응답 경로에서
-  // TypeError 가 났을 수 있어, 동일 요청을 한 번 더 보내면 중복 쓰기 위험. idempotency key 가
-  // 있는 portal-link 같은 호출은 백엔드 단에서 중복 제거되지만, 안전을 위해 일률적으로 멱등 메서드만 재시도.
-  const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
-  const canRetry = method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+// 로 가려지지만 WebKit 은 노출됨. 재시도하면 새 connection 이 만들어져 풀의 stale entry 를
+// 우회 → 일시적 NETWORK_ERROR 회복.
+//
+// PR #192 는 "즉시 1회 재시도" 였으나 동일 증상이 잔존(CCHAKSA-56, /mpa/home getAcademicSummary).
+// 원인은 타이밍이다: 첫 fetch 가 dead socket 의 RST 로 reject 된 "직후" 곧바로 재요청하면
+// NSURLSession 이 아직 그 socket 을 pool 에서 evict 하지 못해 같은(또는 또 다른) stale socket 을
+// 다시 잡을 수 있다. → 재시도 전에 짧은 backoff 를 두어 OS 가 dead socket teardown + 새 TCP/TLS
+// handshake 를 시작할 여유를 준다. 또 /mpa/home 은 mount 시 여러 카드가 GET 을 병렬로 쏘므로
+// (profile·summary·graduation), 재시도가 같은 순간에 몰려 재충돌하지 않도록 jitter 를 더한다.
+// 마지막 시도까지 실패하면 진짜 망 문제로 보고 그대로 propagate.
 
-  try {
-    return await fetch(input, init);
-  } catch (err: unknown) {
-    if (err instanceof TypeError && canRetry) {
-      return fetch(input, init);
+// 멱등 메서드만 재시도 — 비멱등(POST/PATCH/PUT/DELETE)은 첫 요청이 서버에 반영된 뒤 응답 경로에서
+// TypeError 가 났을 수 있어 재요청 시 중복 쓰기 위험. (멱등 GET 은 secure=Authorization 을 실어도
+// 서버 부작용이 없어 안전.) idempotency key 가 있는 portal-link 도 안전을 위해 멱등 메서드만 재시도.
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+// 재시도 전 대기(ms). 인덱스 = 직전 재시도 회차, 배열 길이 = 최대 재시도 횟수. ~250ms 는 dead socket
+// teardown 여유의 하한 — 120ms 면 OS 가 미처 evict 못 해 또 stale socket 을 잡을 위험이 있다.
+const RETRY_BACKOFFS_MS = [250, 600];
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+// base 의 0~30% 를 비율 jitter 로 더해 병렬로 mount 된 카드들의 재시도 시점을 흩뜨린다(재충돌 방지).
+// 비암호용 난수로 충분 — 타이밍 분산 목적뿐, 보안/결정성 요건 없음.
+const backoffWithJitter = (base: number) => base + Math.floor(Math.random() * base * 0.3);
+
+async function fetchWithStaleConnRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  // 401 재발급 경로(customFetch)가 이 함수를 두 번 호출한다. 재발급 후 재요청은 maxRetries=0 으로
+  // 불러 재시도 budget 이 곱(최대 6회)으로 늘어 pool 압박이 커지는 것을 막는다 — 최악 3+1=4회로 제한.
+  maxRetries: number = RETRY_BACKOFFS_MS.length
+): Promise<Response> {
+  const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+  const maxAttempts = IDEMPOTENT_METHODS.has(method) ? Math.min(maxRetries, RETRY_BACKOFFS_MS.length) : 0;
+
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fetch(input, init);
+    } catch (err: unknown) {
+      lastErr = err;
+      // TypeError 만 전송 계층 실패(Load failed)로 보고 재시도. AbortError(DOMException)는 여기 걸리지
+      // 않으므로 사용자/네비게이션 취소는 재요청하지 않는다. 명시적 offline 이면 재시도해도 의미 없고
+      // backoff 만 낭비되므로 곧바로 propagate (navigator.onLine 은 WKWebView 에서 부정확할 수 있어
+      // === false 인 확정 offline 일 때만 단축).
+      const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
+      if (!(err instanceof TypeError) || attempt >= maxAttempts || offline) {
+        throw err;
+      }
+      await sleep(backoffWithJitter(RETRY_BACKOFFS_MS[attempt]));
     }
-    throw err;
   }
+  // 도달 불가 — 루프는 매 회 return 하거나 throw 한다. 타입 안전용 fallback.
+  throw lastErr;
 }
 
 export const createApiConfig = (): ApiConfig => ({
@@ -54,7 +90,9 @@ export const createApiConfig = (): ApiConfig => ({
           const newAccessToken = await refreshAccessTokenStore();
           if (newAccessToken) {
             headers.set('Authorization', `Bearer ${newAccessToken}`);
-            response = await fetchWithStaleConnRetry(input, { ...init, headers });
+            // 재발급 후 재요청은 추가 재시도 없이(0) — 위 호출에서 이미 fresh connection 을 만들었을
+            // 가능성이 높고, 재시도 budget 이 곱으로 늘어 pool 압박이 커지는 것을 막는다.
+            response = await fetchWithStaleConnRetry(input, { ...init, headers }, 0);
           }
         }
       }


### PR DESCRIPTION
## 무엇을 / 왜

iOS 네이티브 WebView(`UA: iOS/3.1.0/debug`)에서 `/mpa/home` 진입 시
`getAcademicSummary` 가 `TypeError: Load failed` 로 떨어지며 **화면에 "500"** 이
표시되는 문제. 이 500은 **서버 5xx가 아니라 클라이언트가 합성한 값**임
(`client.ts` 가 전송 계층 실패를 `ApiError(..., NETWORK_ERROR, 500)` 로 래핑).

근본 원인은 WKWebView 가 idle 후 닫힌 **stale 커넥션을 재사용** → TCP RST →
`TypeError`(~10ms). PR #192 의 `fetchWithStaleConnRetry` 가 이미 1회 재시도하지만
**딜레이 없이 즉시** 재시도해서, NSURLSession 이 죽은 소켓을 pool 에서 evict 하기
전이라 같은(또는 또 다른) stale 소켓을 다시 잡는 경우가 잔존(Sentry CCHAKSA-56).
`/mpa/home` 은 mount 시 GET 3개(profile·summary·graduation)가 병렬로 나가
재시도가 같은 순간에 몰려 재충돌한다. `queryClient` 는 `retry:false` 라 React
Query 의 2차 방어도 없어 그대로 ErrorBoundary 까지 전파된다.

## 변경

`src/shared/api/configs/httpConfig.ts` 의 `fetchWithStaleConnRetry` 보강:

- **재시도 전 backoff 추가** (`[250, 600]ms`) — OS 가 dead socket teardown + 새
  TCP/TLS handshake 를 시작할 여유 확보. (120ms 는 너무 짧아 또 stale 을 잡을 위험.)
- **비율 jitter**(+0~30%) — 병렬 카드들의 재시도 시점을 분산해 재충돌 방지.
- **멱등(GET/HEAD/OPTIONS)만 최대 2회 재시도**, 비멱등(POST/PATCH/PUT/DELETE)은
  0회 — 중복 쓰기 방지.
- `instanceof TypeError` 게이트 유지 — `AbortError`(취소/이탈)는 재시도 안 함.
- **401 재발급 경로 제한**: `customFetch` 가 이 함수를 두 번 호출하므로, 재발급 후
  재요청은 `maxRetries=0` 으로 호출 → secure GET 최악 6회 → 4회로 제한.
- `navigator.onLine === false`(확정 offline)면 backoff 낭비 없이 즉시 propagate.

`src/shared/api/client.ts`: `status=500` 이 합성값(전송 실패)임을 주석으로 명시 —
향후 디버깅 때 백엔드 5xx 오인 방지.

> 성공 경로에는 추가 지연 없음 — 재시도는 실패 시에만 동작.

## 검증

- `yarn type-check` ✅ / `yarn lint`(변경 파일) 에러 0 (기존 `any` 경고만)
- 실제 iOS 기기 확인은 dv 배포 후 필요 — stale-pool 경합은 로컬 재현 불가.

## 잔존 가능성 (배포 후 모니터링)

배포 후에도 같은 빈도로 지속되면 원인이 stale 커넥션이 아니라 교차출처
**CORS/preflight 간헐 실패**일 수 있음(WebKit 은 CORS 실패도 동일한
`TypeError: Load failed` 로 표시). Sentry CCHAKSA-56 breadcrumb 로 구분:
기기별·수일에 걸쳐 흩어지면 stale pool(이 PR), 배포 직후 다수 사용자 동시면 CORS
→ 이 경우 Next rewrite/BFF 로 same-origin 프록시가 근본 해법.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
