### PR TITLE
fix(session): prevent 500 from iron-session unseal throw on stale cookie

### DIFF
--- a/src/lib/auth/__tests__/session.test.ts
+++ b/src/lib/auth/__tests__/session.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// '*' 8개 파트를 갖지만 mac prefix 가 'Fe26.2' 가 아니라, iron-webcrypto 가 'Wrong mac prefix' 를
+// throw 하는 손상 봉인. 이 에러는 iron-session unsealData 의 흡수 allowlist(Expired seal 등 4개)에
+// 없어 그대로 전파되며, 라우트 핸들러에서 500 을 유발하던 실제 케이스다. (앱 webview 의 stale cookie)
+const CORRUPT_SEAL = 'Xx26.2*1*aaa*bbb*ccc*111*ddd*eee';
+
+const hoisted = vi.hoisted(() => ({
+  store: null as null | {
+    get: (name: string) => { name: string; value: string } | undefined;
+    set: (name: string, value: string) => void;
+    delete: (name: string) => void;
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: () => Promise.resolve(hoisted.store),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+function makeCookieStore(initial: Record<string, string>) {
+  const map = new Map(Object.entries(initial));
+  return {
+    get: (name: string) => (map.has(name) ? { name, value: map.get(name) as string } : undefined),
+    set: (name: string, value: string) => {
+      map.set(name, value);
+    },
+    delete: (name: string) => {
+      map.delete(name);
+    },
+  };
+}
+
+describe('getSession', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // iron-session password 는 32자 이상이어야 getIronSession 이 throw 하지 않는다.
+    vi.stubEnv('SESSION_SECRET', 'test-session-secret-at-least-32-characters');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('손상된 봉인 쿠키를 만나면 throw 없이 빈 세션을 반환하고 손상 쿠키를 제거한다', async () => {
+    const store = makeCookieStore({ cchaksa_session: CORRUPT_SEAL });
+    hoisted.store = store;
+
+    const { getSession, SESSION_COOKIE_NAME } = await import('../session');
+
+    // 핵심 회귀: 예외가 새어 나가 500 이 되면 안 된다.
+    const session = await getSession();
+
+    expect(session.accessToken).toBeUndefined();
+    // 손상 쿠키가 제거돼 다음 요청이 같은 500 루프에 빠지지 않는다.
+    expect(store.get(SESSION_COOKIE_NAME)).toBeUndefined();
+  });
+
+  it('쿠키가 없으면 빈 세션을 반환한다', async () => {
+    hoisted.store = makeCookieStore({});
+
+    const { getSession } = await import('../session');
+    const session = await getSession();
+
+    expect(session.accessToken).toBeUndefined();
+  });
+});

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import { captureException } from '@sentry/nextjs';
 import { getIronSession, type SessionOptions } from 'iron-session';
 import { ENV } from '@/config/environment';
 
@@ -13,19 +14,45 @@ export interface SessionData {
   analyticsId?: string;
 }
 
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
 export const sessionOptions: SessionOptions = {
   password: ENV.SESSION_SECRET,
   cookieName: SESSION_COOKIE_NAME,
+  // 봉인(seal) TTL 을 쿠키 maxAge 와 동일하게 명시. ttl 을 생략하면 iron-session 기본값 14일이
+  // 적용돼, 쿠키는 30일간 전송되는데 봉인은 14일 뒤 만료(Expired seal → 빈 세션)되어 세션이
+  // 의도(30일)보다 일찍 조용히 끊긴다. 둘을 맞춰 체감 수명을 일치시킨다.
+  ttl: SESSION_MAX_AGE_SECONDS,
   cookieOptions: {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',
     path: '/',
-    maxAge: 60 * 60 * 24 * 30,
+    maxAge: SESSION_MAX_AGE_SECONDS,
   },
 };
 
+// iron-session 의 unsealData 는 'Expired seal'·'Bad hmac value'·'Cannot find password'·
+// 'Incorrect number of sealed components' 4개 에러만 빈 세션으로 흡수하고, 'Wrong mac prefix'·
+// 'Invalid expiration'·'Invalid password id' 등 봉인 포맷/버전/시크릿 불일치 에러는 그대로 throw 한다.
+// 라우트 핸들러에는 try/catch 가 없어 이 throw 가 500 으로 새어 나가고, 손상된 cchaksa_session 쿠키가
+// GET/POST(네이티브 재교환)/DELETE(로그아웃) 의 getSession() 을 모두 막아 쿠키를 덮어쓰거나 지우는
+// 복구 경로까지 차단되는 자기영속 500 루프가 된다 (앱 webview 의 stale 쿠키에서 관측).
+// → 봉인 해제 실패 시 손상 쿠키를 제거하고 빈 세션을 새로 발급해, 호출 측이 정상 미인증(401)/재교환
+//    흐름을 타게 한다. cookieStore.delete 는 route handler/server action 에서만 허용되므로 방어적으로 감싼다.
 export async function getSession() {
   const cookieStore = await cookies();
-  return getIronSession<SessionData>(cookieStore, sessionOptions);
+  try {
+    return await getIronSession<SessionData>(cookieStore, sessionOptions);
+  } catch (error) {
+    captureException(error, {
+      tags: { scope: 'session', action: 'getSession.unseal' },
+    });
+    try {
+      cookieStore.delete(SESSION_COOKIE_NAME);
+    } catch {
+      // read-only 컨텍스트(server component 등) — 무시. 아래 재호출이 빈 세션을 돌려준다.
+    }
+    return getIronSession<SessionData>(cookieStore, sessionOptions);
+  }
 }


### PR DESCRIPTION
## 배경 / 문제

iron-session 의 `unsealData` 는 `Expired seal`·`Bad hmac value`·`Cannot find password`·`Incorrect number of sealed components` 4개 에러만 빈 세션으로 흡수하고, `Wrong mac prefix`·`Invalid expiration`·`Invalid password id` 등 **봉인 포맷/버전/시크릿 불일치** 에러는 그대로 throw 한다.

세션 라우트 핸들러(`GET`/`POST`/`DELETE /api/session`, `POST /api/session/refresh`, `/auth/callback`)에 try/catch 가 없어 이 throw 가 **500** 으로 새어 나간다. 더 큰 문제는 **자기영속성**이다 — 손상된 `cchaksa_session` 쿠키가 `getSession()` 을 호출하는 모든 경로를 동시에 막는다:

- `GET`(하이드레이션) → 500
- `POST`(네이티브 재익스체인지) → 500, `session.save()` 도달 못 해 **손상 쿠키를 덮어쓰지 못함**
- `DELETE`(로그아웃) → 500, **쿠키를 지우지도 못함**
- 즉 쿠키를 치우려면 `getSession()` 이 성공해야 하는데 그 쿠키 때문에 throw → **복구 경로까지 전부 차단되는 500 루프**

iOS WKWebView 가 `SESSION_SECRET` 회전 / iron-session 버전업 / 봉인 포맷 변경 *이전*에 발급된 stale 쿠키를 보관(WKAppBoundDomains)했다가 *이후*에 읽을 때 발생하며, 실제 앱 webview 에서 관측됐다.

## 변경 사항

- **`getSession()` 을 try/catch 로 감쌈** — 봉인 해제 실패 시 손상 쿠키 삭제 + 빈 세션 재발급 + Sentry 캡처. 5개 호출처(와 미래 호출처)가 한 번에 정상 미인증(401)/재익스체인지 흐름을 타게 한다. (`cookieStore.delete` 는 route handler/server action 에서만 허용되므로 방어적으로 try/catch 로 감쌈.)
- **`sessionOptions.ttl` 을 쿠키 `maxAge`(30일)와 동일하게 명시** — 생략 시 iron-session 기본값 14일이 적용돼, 쿠키는 30일 전송되는데 봉인은 14일에 만료(Expired seal)되어 세션이 의도보다 일찍 조용히 끊기던 불일치를 해소.
- **회귀 테스트 추가** — 손상 봉인 → throw 없이 빈 세션 + 쿠키 제거 / 쿠키 없음 → 빈 세션.

## 영향 범위

`src/lib/auth/session.ts` 의 `getSession()` 한 곳. 이를 호출하는 5개 진입점이 자동으로 혜택을 받는다. **정상 쿠키 동작은 변경 없음** — 봉인 해제가 성공하는 경로(정상 토큰 폐기·refresh·destroy)는 그대로다.

## 테스트

- `src/lib/auth/__tests__/session.test.ts` 추가 (2 케이스)
- [ ] CI 통과 확인
- [ ] 로컬 webview stale-cookie 재현 시나리오 (선택)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
