### PR TITLE
fix: address CodeRabbit review on #236

### DIFF
--- a/src/features/dashboard/apis/queries/useWithdrawDisplayName.ts
+++ b/src/features/dashboard/apis/queries/useWithdrawDisplayName.ts
@@ -35,5 +35,7 @@ export function useWithdrawDisplayName(): string | undefined {
     staleTime: 5 * 60 * 1000,
   });
 
-  return data?.name;
+  // queryKey 를 useProfileQuery 와 공유하므로, 미연동인데 다른 경로에서 채워둔 캐시가 잡힐 수 있다.
+  // 문서화된 계약(미연동/조회 전이면 undefined)을 보장하기 위해 isPortalLinked 로 한 번 더 가드한다.
+  return isPortalLinked === true ? data?.name : undefined;
 }

--- a/src/lib/analytics/amplitude.ts
+++ b/src/lib/analytics/amplitude.ts
@@ -107,14 +107,27 @@ function clearLegacyAcademicUserProperties(analyticsId: string): void {
   for (const key of LEGACY_ACADEMIC_USER_PROPS) {
     identify.unset(key);
   }
-  amplitude.identify(identify);
 
+  // in-memory 가드는 즉시 세팅 — 같은 세션 내 동시/재호출의 중복 전송을 막는다.
   legacyCleanedThisSession.add(analyticsId);
-  try {
-    localStorage.setItem(flagKey, '1');
-  } catch {
-    // 플래그 저장 실패 — in-memory 가드가 세션 1회를 막아줌. 무시.
-  }
+
+  // localStorage 영구 플래그는 전송이 성공(code 200)한 뒤에만 기록한다. 즉시 기록하면 전송이
+  // 실패해도 "정리 완료" 로 남아 다음 세션에서 재시도되지 않는다 → 레거시 학적 값이 영구히 남는다.
+  amplitude
+    .identify(identify)
+    .promise.then(result => {
+      if (result.code !== 200) {
+        return; // 전송 실패 — 영구 플래그 미기록 → 다음 hydration 에서 재시도
+      }
+      try {
+        localStorage.setItem(flagKey, '1');
+      } catch {
+        // 플래그 저장 실패 — in-memory 가드가 세션 1회를 막아줌. 무시.
+      }
+    })
+    .catch(() => {
+      // 전송 거부 — 영구 플래그 미기록으로 다음 세션 재시도. 무시.
+    });
 }
 
 /**

--- a/src/lib/auth/__tests__/session.test.ts
+++ b/src/lib/auth/__tests__/session.test.ts
@@ -11,6 +11,8 @@ const hoisted = vi.hoisted(() => ({
     set: (name: string, value: string) => void;
     delete: (name: string) => void;
   },
+  // resetModules 로 매 테스트마다 session 모듈을 재임포트해도 동일 인스턴스를 유지하기 위해 hoisted 에 둔다.
+  captureException: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({
@@ -18,7 +20,7 @@ vi.mock('next/headers', () => ({
 }));
 
 vi.mock('@sentry/nextjs', () => ({
-  captureException: vi.fn(),
+  captureException: hoisted.captureException,
 }));
 
 function makeCookieStore(initial: Record<string, string>) {
@@ -37,6 +39,7 @@ function makeCookieStore(initial: Record<string, string>) {
 describe('getSession', () => {
   beforeEach(() => {
     vi.resetModules();
+    hoisted.captureException.mockClear();
     // iron-session password 는 32자 이상이어야 getIronSession 이 throw 하지 않는다.
     vi.stubEnv('SESSION_SECRET', 'test-session-secret-at-least-32-characters');
   });
@@ -57,6 +60,8 @@ describe('getSession', () => {
     expect(session.accessToken).toBeUndefined();
     // 손상 쿠키가 제거돼 다음 요청이 같은 500 루프에 빠지지 않는다.
     expect(store.get(SESSION_COOKIE_NAME)).toBeUndefined();
+    // 복구 경로의 관측성: 봉인 해제 실패를 Sentry 로 보고했는지 검증.
+    expect(hoisted.captureException).toHaveBeenCalledTimes(1);
   });
 
   it('쿠키가 없으면 빈 세션을 반환한다', async () => {


### PR DESCRIPTION
## 개요

[PR #236](https://github.com/gyumong/chukchuk-haksa/pull/236)의 CodeRabbit 리뷰(actionable 4건)를 `dev` 기준 브랜치에 반영합니다. CodeRabbit 지침대로 각 항목을 현재 코드와 대조해 유효한 것만 최소 변경으로 수정했습니다.

## 반영 (3건)

### 1. `useWithdrawDisplayName` — `isPortalLinked` 가드 추가
queryKey를 `useProfileQuery`와 공유하므로, 미연동 유저인데 다른 경로에서 채워둔 프로필 캐시가 잡혀 이름이 반환될 수 있었습니다. 문서화된 계약(미연동/조회 전이면 `undefined`)을 보장하도록 반환부를 `isPortalLinked === true`로 한 번 더 가드했습니다.

### 2. `amplitude.ts` — 레거시 정리 플래그를 전송 성공 후에만 영구 기록
`amplitude.identify()`는 비동기인데 localStorage 영구 플래그를 즉시 기록하고 있어, 전송이 실패해도 "정리 완료"로 남아 다음 hydration에서 재시도되지 않았습니다(레거시 학적 UserProperty가 영구히 잔존).
- `identify(...).promise`를 받아 **성공(code 200) 시에만** localStorage 플래그를 기록 → 실패 시 다음 세션에서 재시도.
- 단, in-memory 세션 가드(`legacyCleanedThisSession`)는 **즉시** 세팅을 유지합니다. 같은 세션 내 동시/재호출의 중복 전송 방지가 이 가드의 본래 목적이고, 실패 시 재시도는 영구 플래그(localStorage)로 충분히 보장되기 때문입니다. (리뷰는 둘 다 `.then()`으로 옮기길 제안했으나, in-memory를 즉시 유지하는 편이 세션 내 중복 전송을 더 잘 막습니다.)

### 3. `session.test.ts` — Sentry `captureException` 호출 검증 추가
손상 봉인 쿠키 복구 테스트가 관측성(Sentry 보고)을 검증하지 않았습니다. `captureException` 호출을 단언하도록 추가하고, `vi.resetModules()`로 모듈이 재임포트돼도 동일 mock 인스턴스를 유지하도록 mock을 `vi.hoisted`로 고정했습니다.

## 스킵 (1건)

### `(mpa)/layout.module.scss` 반응형 디자인 제안 — 스킵
`.contentScroll`/`.contentPlain`는 이미 디자인 시스템 믹스인(`content-padding`, `safe-area-bottom`)을 사용하며, 같은 파일에 머지된 `.content` 형제 클래스 및 코드 주석에 명시된 웹 레이아웃 패리티 의도와 일치합니다. 고정 600px 모바일 컨테이너로 태블릿/데스크톱 변형이 없어 `device` 브레이크포인트를 추가하면 오히려 문서화된 의도와 충돌합니다. 가이드라인 휴리스틱의 false positive로 판단해 스킵했습니다.

## 검증
- `yarn type-check` 통과
- `vitest run src/lib/auth/__tests__/session.test.ts` 2/2 통과
- 변경 파일 ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포털 연동 상태 검증 로직을 강화하여 데이터 일관성 보장
  * 레거시 사용자 데이터 정리의 신뢰성 향상 및 중복 처리 방지

* **테스트**
  * 손상된 세션 복구 경로에 대한 테스트 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->