### PR TITLE
feat: 과목 리스트 학기 코드를 짧은 라벨(1/2/여름/겨울)로 표시

### DIFF
--- a/src/features/academic/components/shared/Accordion/CourseList/CourseList.tsx
+++ b/src/features/academic/components/shared/Accordion/CourseList/CourseList.tsx
@@ -1,3 +1,4 @@
+import { getSemesterShortLabel } from '@/lib/utils/semester';
 import type { CourseListProps } from '../types';
 import styles from './CourseList.module.scss';
 
@@ -11,7 +12,9 @@ export default function CourseList({ courses, isCompleted }: CourseListProps) {
             {course.liberalAreaCode != null && (
               <span className={styles.area}>{course.liberalAreaCode}영역</span>
             )}
-            <span className={styles.semester}>{course.year}-{course.semester}</span>
+            <span className={styles.semester}>
+              {course.year}-{getSemesterShortLabel(course.semester)}
+            </span>
           </div>
           <div className={styles.courseGrade}>
             <span className={styles.credits}>{course.credits}학점</span>

--- a/src/lib/utils/__tests__/semester.test.ts
+++ b/src/lib/utils/__tests__/semester.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getSemesterShortLabel } from '../semester';
+
+describe('getSemesterShortLabel', () => {
+  it('정규학기 코드(10/20)를 1/2 로 변환한다', () => {
+    expect(getSemesterShortLabel(10)).toBe('1');
+    expect(getSemesterShortLabel(20)).toBe('2');
+  });
+
+  it('계절학기 코드(15/25)를 여름/겨울 로 변환한다', () => {
+    expect(getSemesterShortLabel(15)).toBe('여름');
+    expect(getSemesterShortLabel(25)).toBe('겨울');
+  });
+
+  it('알 수 없는 코드는 throw 없이 원본 숫자를 문자열로 반환한다', () => {
+    expect(getSemesterShortLabel(99)).toBe('99');
+    expect(getSemesterShortLabel(0)).toBe('0');
+  });
+});

--- a/src/lib/utils/semester.ts
+++ b/src/lib/utils/semester.ts
@@ -89,6 +89,34 @@ export function getSemesterDisplay(semesterCode: number): string {
 }
 
 /**
+ * 학기 코드를 짧은 표시용 라벨로 변환 (throw 없이 안전).
+ * 백엔드가 raw 코드(10/15/20/25)로 내려주는 학기를 화면 표기용 1/2/여름/겨울 로 매핑.
+ * 알 수 없는 코드는 렌더가 깨지지 않도록 원본 숫자를 문자열로 그대로 반환한다.
+ * @param semesterCode 학기 코드 (10, 15, 20, 25)
+ * @returns 짧은 학기 라벨 ('1', '2', '여름', '겨울')
+ *
+ * @example
+ * getSemesterShortLabel(10) // '1'
+ * getSemesterShortLabel(20) // '2'
+ * getSemesterShortLabel(15) // '여름'
+ * getSemesterShortLabel(25) // '겨울'
+ */
+export function getSemesterShortLabel(semesterCode: number): string {
+  switch (semesterCode) {
+    case 10:
+      return '1';
+    case 15:
+      return '여름';
+    case 20:
+      return '2';
+    case 25:
+      return '겨울';
+    default:
+      return String(semesterCode);
+  }
+}
+
+/**
  * 정규학기 여부 확인
  * @param semesterCode 학기 코드
  * @returns 정규학기 여부


### PR DESCRIPTION
## 배경
백엔드가 이수 학기를 raw 코드(10/15/20/25)로 내려주어, 과목 리스트에 `2024-20`, `2026-10` 처럼 코드가 그대로 노출됐습니다.

## 변경
- `getSemesterShortLabel(code)` 추가: `10→1`, `20→2`, `15→여름`, `25→겨울`
  - 기존 `getSemesterFromCode`는 미상 코드에서 throw → 렌더가 깨질 수 있어, 새 함수는 **throw 없이** 알 수 없는 코드는 원본 숫자 문자열로 폴백
- `CourseList`에서 raw `course.semester` 대신 짧은 라벨로 표시 (공유 컴포넌트라 complete/academic-detail 등 모든 소비처 반영)
- 단위 테스트 추가

결과: `2024-2`, `2026-1`, `2024-여름`, `2024-겨울`

## 검증
- `yarn type-check` ✅ / `yarn lint` ✅ (0 errors) / 새 테스트 3개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
