### PR TITLE
feat: 가입 퍼널에 외국어인증제도 확인 단계 추가

### DIFF
--- a/src/app/(funnel)/foreign-language-cert/page.module.scss
+++ b/src/app/(funnel)/foreign-language-cert/page.module.scss
@@ -1,0 +1,77 @@
+@use '@/styles/color.scss' as colors;
+@use '@/styles/radius.scss' as radius;
+@use '@/styles/spacing.scss' as spacing;
+@use '@/styles/typography.scss' as typography;
+@use '@/styles/utilities.scss' as utilities;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  @include utilities.funnel-page-spacing;
+  // 고정 '다음' 버튼(fixed) 뒤로 마지막 카드가 가리지 않도록 하단 여유 확보.
+  padding-bottom: calc(spacing.$space-66 + spacing.$space-48);
+}
+
+.content {
+  flex: 1;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$space-12;
+  margin: spacing.$space-40 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+// 시험별 기준 카드 — 상단 캡션(학과)·하단 행(시험명/통과 기준).
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$space-6;
+  padding: spacing.$space-18 spacing.$space-20;
+  background-color: colors.$gray-300;
+
+  @include radius.radius-md;
+}
+
+.caption {
+  color: colors.$gray-500;
+
+  @include typography.body-sm;
+  @include typography.font-weight-regular;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: spacing.$space-16;
+}
+
+.examName {
+  color: colors.$black-100;
+
+  @include typography.body-md;
+  @include typography.font-weight-bold;
+}
+
+.examValue {
+  color: colors.$purple-100;
+  text-align: right;
+  word-break: keep-all;
+
+  @include typography.body-md;
+  @include typography.font-weight-bold;
+}
+
+// 미매핑 학과 등 기준 목록이 없을 때의 안내.
+.note {
+  margin: spacing.$space-40 0 0;
+  text-align: center;
+  color: colors.$gray-500;
+
+  @include typography.body-md;
+  @include typography.font-weight-regular;
+}

--- a/src/app/(funnel)/foreign-language-cert/page.module.scss
+++ b/src/app/(funnel)/foreign-language-cert/page.module.scss
@@ -8,6 +8,7 @@
   display: flex;
   flex-direction: column;
   @include utilities.funnel-page-spacing;
+
   // 고정 '다음' 버튼(fixed) 뒤로 마지막 카드가 가리지 않도록 하단 여유 확보.
   padding-bottom: calc(spacing.$space-66 + spacing.$space-48);
 }

--- a/src/app/(funnel)/foreign-language-cert/page.tsx
+++ b/src/app/(funnel)/foreign-language-cert/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { FixedButton } from '@/components/ui';
+import { ROUTES } from '@/constants/routes';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
+import { useLanguageCertRequirementQuery } from '@/features/academic/apis/queries/useLanguageCertRequirementQuery';
+import {
+  getRequirementValue,
+  getTestLabel,
+  sortRequirements,
+} from '@/features/academic/utils/languageCertDisplay';
+import { EVENTS, track } from '@/lib/analytics';
+import { isInWebView, postBridgeMessage } from '@/lib/webview';
+import AsyncBoundary from '@/shared/components/AsyncBoundary';
+import { FunnelHeadline } from '../components';
+import styles from './page.module.scss';
+
+// target-score 에서 이전해 온 webview 완료 신호. 첫 가입(funnel) 흐름의 '마지막' 단계인 이 화면에서
+// 송출한다. MPA(재연동) 흐름은 /mpa/portal-login/scraping 에서 자체 송출하므로 이 변경과 무관하다.
+// 프로토콜: 네이티브는 이 신호를 받으면 webview 를 닫고 dashboard 를 갱신한다.
+const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
+
+// 외국어 인증 기준(학과·입학년도별 시험 통과 기준)을 '확인 전용'으로 노출한다.
+// 선택/제출 동작은 없으며, 불러온 시험 목록을 보여주기만 한다.
+function ForeignLanguageCertInfo() {
+  const { data: requirement } = useLanguageCertRequirementQuery();
+  const { departmentName, admissionYear, note } = requirement;
+  const requirements = sortRequirements(requirement.requirements);
+
+  const yearLabel = admissionYear != null ? `${String(admissionYear).slice(-2)}학번` : '';
+  const deptYear = [departmentName, yearLabel].filter(Boolean).join(' ');
+  const title = deptYear
+    ? `${deptYear}의<br/>외국어인증제도 필요 점수에요`
+    : `외국어인증제도<br/>필요 점수에요`;
+
+  return (
+    <>
+      <FunnelHeadline
+        title={title}
+        description="외국어인증제도 요건을 확인해주세요."
+        highlightText={deptYear || '외국어인증제도'}
+      />
+
+      {requirements.length > 0 ? (
+        <ul className={styles.list}>
+          {requirements.map((req, index) => (
+            <li key={`${req.testType ?? 'req'}-${index}`} className={styles.card}>
+              {departmentName && <span className={styles.caption}>{departmentName}</span>}
+              <div className={styles.row}>
+                <span className={styles.examName}>{getTestLabel(req.testType)}</span>
+                <span className={styles.examValue}>{getRequirementValue(req)}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className={styles.note}>{note ?? '학과별 외국어 인증 기준 정보를 준비 중입니다.'}</p>
+      )}
+    </>
+  );
+}
+
+// 마지막 온보딩 단계에서는 기준 조회 실패가 재시도/로그아웃 CTA(ApiErrorFallback·DefaultErrorFallback)로
+// 노출되어 '다음'과 충돌하지 않도록, 조용한 안내만 보여준다. 실제 진행은 경계 밖의 '다음' 버튼이 담당.
+function RequirementErrorNote() {
+  return (
+    <p className={styles.note}>
+      외국어인증제도 기준을 불러오지 못했어요.
+      <br />
+      아래 ‘다음’을 눌러 계속할 수 있어요.
+    </p>
+  );
+}
+
+export default function ForeignLanguageCertPage() {
+  const router = useInternalRouter();
+
+  const handleNext = () => {
+    track(EVENTS.UNIV_FOREIGN_LANGUAGE_CERTIFICATION_BTN_TAP);
+    if (isInWebView()) {
+      const posted = postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
+      if (!posted) {
+        // 브리지 송출 실패(race/예외) 시 사용자가 webview 에 정지하지 않도록 기존 fallback 으로 이동.
+        // Sentry 캡쳐는 bridge.ts 내부.
+        router.push(`${ROUTES.MAIN}`);
+      }
+    } else {
+      router.push(`${ROUTES.MAIN}`);
+    }
+  };
+
+  return (
+    <ProtectedRoute requirePortalLinked={true}>
+      <div className={styles.container}>
+        {/* 기준 조회 실패/로딩은 AsyncBoundary 가 처리하되, '다음' 버튼은 경계 밖에 두어
+            조회가 실패해도 사용자가 온보딩을 끝낼 수 있게 한다. */}
+        <div className={styles.content}>
+          <AsyncBoundary customErrorFallback={RequirementErrorNote}>
+            <ForeignLanguageCertInfo />
+          </AsyncBoundary>
+        </div>
+        <FixedButton onClick={handleNext}>다음</FixedButton>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/app/(funnel)/target-score/page.tsx
+++ b/src/app/(funnel)/target-score/page.tsx
@@ -7,13 +7,8 @@ import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { useSetTargetGpaMutation } from '@/features/student/apis/queries/useSetTargetGpaMutation';
 import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
 import { EVENTS, track } from '@/lib/analytics';
-import { isInWebView, postBridgeMessage } from '@/lib/webview';
 import { FunnelHeadline, ScoreInput } from '../components';
 import styles from './page.module.scss';
-
-// MPA(webview) 진입의 첫 연동 완료 신호. 네이티브가 webview 닫고 dashboard 갱신.
-// 프로토콜: docs/mpa-school-link-handoff.md
-const BRIDGE_DONE_PORTAL_LINK = 'done:portal-link';
 
 export default function TargetScorePage() {
   const [score, setScore] = useState('3.5');
@@ -25,16 +20,9 @@ export default function TargetScorePage() {
     track(EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP, { gpa });
     try {
       await mutation.mutateAsync(gpa);
-      if (isInWebView()) {
-        const posted = postBridgeMessage(BRIDGE_DONE_PORTAL_LINK);
-        if (!posted) {
-          // 브리지 송출 실패(race/예외) 시 사용자가 webview 에 정지하지 않도록
-          // 기존 브라우저 경로와 동일한 fallback 으로 이동. Sentry 캡쳐는 bridge.ts 내부.
-          router.push(`${ROUTES.MAIN}`);
-        }
-      } else {
-        router.push(`${ROUTES.MAIN}`);
-      }
+      // 학점 설정 후 외국어인증제도 확인 단계로 이동. webview 완료 신호(done:portal-link)는
+      // 마지막 단계인 외국어인증제도 화면에서 송출한다(브라우저·webview 공통).
+      router.push(`${ROUTES.FUNNEL.FOREIGN_LANGUAGE_CERT}`);
     } catch (error) {
       console.error('Failed to set target score:', error);
       alert(error instanceof Error ? error.message : '목표 학점 설정에 실패했습니다.');

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
     PORTAL_LOGIN: '/portal-login',
     SCRAPING: '/scraping',
     TARGET_SCORE: '/target-score',
+    FOREIGN_LANGUAGE_CERT: '/foreign-language-cert',
   },
   AUTH: {
     CALLBACK: '/auth/callback',

--- a/src/features/academic/components/progress/LanguageCertInfoDialog/LanguageCertInfoDialog.tsx
+++ b/src/features/academic/components/progress/LanguageCertInfoDialog/LanguageCertInfoDialog.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import type { LanguageCertRequirementResponse, Requirement } from '@/shared/api/data-contracts';
+import type { LanguageCertRequirementResponse } from '@/shared/api/data-contracts';
+import { getRequirementValue, getTestLabel, sortRequirements } from '@/features/academic/utils/languageCertDisplay';
 import styles from './LanguageCertInfoDialog.module.scss';
 
 interface LanguageCertInfoDialogProps {
@@ -10,47 +11,10 @@ interface LanguageCertInfoDialogProps {
   requirement: LanguageCertRequirementResponse;
 }
 
-// 시험 종류 코드 → 표시 라벨. 백엔드는 testType 코드만 내려주고 표시 라벨은 프론트에서 매핑한다.
-// (TORFL_FLEX 등 일부 라벨은 실제 응답 확인 후 디자인과 맞춰 조정 필요)
-const TEST_TYPE_LABEL: Record<string, string> = {
-  TOEIC: 'TOEIC',
-  TOEFL_IBT: 'TOEFL (IBT)',
-  TEPS: 'TEPS',
-  OPIC: 'OPIc',
-  TOEIC_SPEAKING: 'TOEIC Speaking',
-  JPT_JLPT: 'JPT/JLPT',
-  NEW_HSK: '新HSK',
-  TORFL_FLEX: 'TORFL/FLEX',
-  DELF: 'DELF',
-};
-
-function getTestLabel(testType: Requirement['testType']): string {
-  if (!testType) {
-    return '';
-  }
-  return TEST_TYPE_LABEL[testType] ?? testType;
-}
-
-// displayText 를 우선 사용하고, 없을 때만 점수/등급으로 폴백 구성한다.
-function getRequirementValue(req: Requirement): string {
-  if (req.displayText) {
-    return req.displayText;
-  }
-  if (req.minimumScore != null) {
-    return `${req.minimumScore}점 이상`;
-  }
-  if (req.minimumGrade) {
-    return `${req.minimumGrade} 이상`;
-  }
-  return '';
-}
-
 // 졸업요건 '외국어인증제도' 설명 팝업. 공용 ConfirmDialog 를 단일 버튼(hideCancel) + 리치 본문으로 재사용한다.
 export function LanguageCertInfoDialog({ isOpen, onClose, requirement }: LanguageCertInfoDialogProps) {
   const { departmentName, admissionYear, note } = requirement;
-  const requirements = [...(requirement.requirements ?? [])].sort(
-    (a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
-  );
+  const requirements = sortRequirements(requirement.requirements);
 
   const yearLabel = admissionYear != null ? `${String(admissionYear).slice(-2)}학번` : '';
   const deptYear = [departmentName, yearLabel].filter(Boolean).join(' ');

--- a/src/features/academic/utils/languageCertDisplay.ts
+++ b/src/features/academic/utils/languageCertDisplay.ts
@@ -1,8 +1,11 @@
 import type { Requirement } from '@/shared/api/data-contracts';
 
+type RequirementTestType = NonNullable<Requirement['testType']>;
+
 // 시험 종류 코드 → 표시 라벨. 백엔드는 testType 코드만 내려주고 표시 라벨은 프론트에서 매핑한다.
+// 키를 Requirement['testType'] 계약으로 제한해 오타·비의도 키를 컴파일 타임에 차단한다.
 // (TORFL_FLEX 등 일부 라벨은 실제 응답 확인 후 디자인과 맞춰 조정 필요)
-export const TEST_TYPE_LABEL: Record<string, string> = {
+export const TEST_TYPE_LABEL: Partial<Record<RequirementTestType, string>> = {
   TOEIC: 'TOEIC',
   TOEFL_IBT: 'TOEFL (IBT)',
   TEPS: 'TEPS',

--- a/src/features/academic/utils/languageCertDisplay.ts
+++ b/src/features/academic/utils/languageCertDisplay.ts
@@ -1,0 +1,42 @@
+import type { Requirement } from '@/shared/api/data-contracts';
+
+// 시험 종류 코드 → 표시 라벨. 백엔드는 testType 코드만 내려주고 표시 라벨은 프론트에서 매핑한다.
+// (TORFL_FLEX 등 일부 라벨은 실제 응답 확인 후 디자인과 맞춰 조정 필요)
+export const TEST_TYPE_LABEL: Record<string, string> = {
+  TOEIC: 'TOEIC',
+  TOEFL_IBT: 'TOEFL (IBT)',
+  TEPS: 'TEPS',
+  OPIC: 'OPIc',
+  TOEIC_SPEAKING: 'TOEIC Speaking',
+  JPT_JLPT: 'JPT/JLPT',
+  NEW_HSK: '新HSK',
+  TORFL_FLEX: 'TORFL/FLEX',
+  DELF: 'DELF',
+};
+
+/** 시험 종류 코드를 표시 라벨로 변환. 미매핑 코드는 코드 원문을 그대로 노출한다. */
+export function getTestLabel(testType: Requirement['testType']): string {
+  if (!testType) {
+    return '';
+  }
+  return TEST_TYPE_LABEL[testType] ?? testType;
+}
+
+/** displayText 를 우선 사용하고, 없을 때만 점수/등급으로 폴백 구성한다. */
+export function getRequirementValue(req: Requirement): string {
+  if (req.displayText) {
+    return req.displayText;
+  }
+  if (req.minimumScore != null) {
+    return `${req.minimumScore}점 이상`;
+  }
+  if (req.minimumGrade) {
+    return `${req.minimumGrade} 이상`;
+  }
+  return '';
+}
+
+/** sortOrder 오름차순으로 정렬된 사본을 반환(원본 불변). */
+export function sortRequirements(requirements?: Requirement[]): Requirement[] {
+  return [...(requirements ?? [])].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+}


### PR DESCRIPTION
## 배경
첫 가입 → 학점 설정(target-score) 다음에, 학과·입학년도별 외국어인증제도 통과 기준을 **확인 전용**으로 보여주는 단계를 추가합니다. (선택/제출 없음)

## 변경
- **새 퍼널 페이지** `(funnel)/foreign-language-cert`
  - 헤드라인: `{학과} {YY}학번의 / 외국어인증제도 필요 점수에요` (동적)
  - 설명: `외국어인증제도 요건을 확인해주세요.`
  - 불러온 시험 목록 view-only (TOEIC / 550점 이상 식). 기존 `useLanguageCertRequirementQuery` 재사용
  - `AsyncBoundary`로 감싸되 `다음` 버튼은 **에러 경계 밖**에 두어, 기준 조회 실패에도 온보딩을 끝낼 수 있게 함. 실패 시 재시도/로그아웃 CTA 대신 조용한 안내(`customErrorFallback`)만 노출
- `routes`: `FUNNEL.FOREIGN_LANGUAGE_CERT` 추가
- `target-score`: 제출 후 새 단계로 이동. **webview 완료 신호(`done:portal-link`)를 마지막 단계인 외국어인증제도 화면으로 이전**
  - MPA 재연동 흐름(`/mpa/portal-login/scraping`)은 자체 송출이라 영향 없음
- **refactor**: 시험 라벨/점수 표시 헬퍼를 `languageCertDisplay`로 추출해 `LanguageCertInfoDialog`와 공유(중복 제거)

## 플로우
`scraping → agreement → complete → target-score → **foreign-language-cert(신규)** → MAIN/webview 완료`

## 검증
- `yarn type-check` ✅ / `yarn lint` ✅ (0 errors) / `yarn build` ✅ (새 라우트 prerender, 29/29)
- 멀티에이전트 적대적 리뷰 후 확정 2건 반영 (에러 폴백 CTA 충돌 → `customErrorFallback`, import alias 통일)

## 리뷰 포인트
- 목업의 "외국어인증제도 미완료" 상태 칩 + 선택 UI는 view-only 요청에 따라 제거했습니다.
- webview 완료 신호 위치 이전이 핵심 동작 변경입니다(첫 가입 퍼널 한정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 외국어 인증제도 기준 확인 페이지가 온보딩 마지막 단계로 추가되었습니다. 사용자가 목표 학점 설정 후 해당 학과 및 입학년도에 맞는 외국어 인증 시험 기준을 확인할 수 있습니다.

* **개선 사항**
  * 온보딩 플로우가 개선되어 목표 학점 설정 후 외국어 인증 기준 확인 페이지로 자동 이동됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->