### PR TITLE
feat: 홈 갱신하기에 GAM 보상형 광고 게이트 추가 (web)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -63,6 +63,10 @@ jobs:
       # 환경 공통 (Variables 탭 값, Secret 아님)
       NEXT_PUBLIC_MAINTENANCE_MODE: ${{ vars.NEXT_PUBLIC_MAINTENANCE_MODE }}
       NEXT_PUBLIC_MAINTENANCE_MESSAGE: ${{ vars.NEXT_PUBLIC_MAINTENANCE_MESSAGE }}
+
+      # 광고 (GAM rewarded) 네트워크 코드 — 비밀 아님(클라 번들/광고요청에 노출). staging/prod 공통.
+      # rewarded 광고 단위 경로 `/<코드>/cchaksa_resync_rewarded` 구성에 사용(adUnits.ts). 미설정 시 광고 비활성.
+      NEXT_PUBLIC_GAM_NETWORK_CODE: '23358406176'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/app/(main)/main/layout.tsx
+++ b/src/app/(main)/main/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { PropsWithChildren } from 'react';
+import Script from 'next/script';
 import { TopNavigation } from '@/components/ui/TopNavigation';
 import { ROUTES } from '@/constants/routes';
 import ProtectedRoute from '@/features/auth/components/ProtectedRoute';
@@ -15,6 +16,12 @@ export default function FunnelLayout({ children }: PropsWithChildren) {
 
   return (
     <ProtectedRoute requirePortalLinked={true} portalLinkRedirectTo={ROUTES.FUNNEL.PORTAL_LOGIN}>
+      {/* GAM(GPT) — 브라우저 /main 에서만 로드. (mpa) 웹뷰엔 절대 로드하지 않는다(AdSense/GAM 앱 정책 위반). */}
+      <Script
+        id="gpt-js"
+        src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+        strategy="afterInteractive"
+      />
       <div className={styles.container}>
         <TopNavigation.Preset
           title="수원대학교"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from '@/features/auth/contexts/AuthContext';
 import { AnalyticsProvider } from '@/lib/analytics';
 import { RemoteConfigProvider } from '@/lib/remote-config';
 import MaintenancePage from '@/components/MaintenancePage';
+import { Toaster } from '@/components/ui/Toast';
 import { GlobalErrorReporter } from '@/lib/error-reporting';
 import NotifyRenderedToNative from '@/lib/webview/NotifyRenderedToNative';
 import '../styles/global.scss';
@@ -83,6 +84,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         )}
         <GlobalErrorReporter />
         <NotifyRenderedToNative />
+        <Toaster />
         <Analytics />
         {/* Cloudflare Web Analytics: 스크립트 삽입 */}
         <Script

--- a/src/components/ui/Toast/Toaster.module.scss
+++ b/src/components/ui/Toast/Toaster.module.scss
@@ -30,7 +30,8 @@
 }
 
 .toast {
-  pointer-events: auto;
+  // 정보성 토스트는 뒤 화면 조작을 막지 않도록 클릭을 통과시킨다.
+  pointer-events: none;
   padding: spacing.$space-12 spacing.$space-16;
 
   background-color: rgba(0, 0, 0, 0.85);
@@ -55,5 +56,12 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+// 모션 최소화 선호 시 등장 애니메이션(장식)을 끈다.
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
   }
 }

--- a/src/components/ui/Toast/Toaster.module.scss
+++ b/src/components/ui/Toast/Toaster.module.scss
@@ -1,0 +1,59 @@
+@use '@/styles/color.scss' as color;
+@use '@/styles/spacing.scss' as spacing;
+@use '@/styles/typography.scss' as typography;
+@use '@/styles/radius.scss' as radius;
+@use '@/styles/device.scss' as device;
+
+.viewport {
+  position: fixed;
+  left: 50%;
+  bottom: calc(#{spacing.$space-32} + env(safe-area-inset-bottom, 0px));
+  transform: translateX(-50%);
+
+  // ConfirmDialog overlay(1000) 등 page 내 fixed 요소보다 위에 떠야 함.
+  z-index: 2000;
+
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$space-8;
+
+  width: 100%;
+  max-width: 360px;
+  padding: 0 spacing.$space-24;
+
+  // 토스트 자체만 포인터 이벤트를 받고, 뒤 화면 조작은 막지 않는다.
+  pointer-events: none;
+
+  @include device.medium-expanded {
+    max-width: 400px;
+  }
+}
+
+.toast {
+  pointer-events: auto;
+  padding: spacing.$space-12 spacing.$space-16;
+
+  background-color: rgba(0, 0, 0, 0.85);
+  color: color.$white;
+  text-align: center;
+  white-space: pre-line;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+
+  @include radius.radius-md;
+  @include typography.body-sm;
+  @include typography.font-weight-medium;
+
+  animation: toast-in 200ms ease-out;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/ui/Toast/Toaster.tsx
+++ b/src/components/ui/Toast/Toaster.tsx
@@ -11,24 +11,21 @@ const ToastRow = ({ toast }: { toast: ToastItem }) => {
     return () => clearTimeout(timer);
   }, [toast.id, toast.duration]);
 
-  return (
-    <div className={styles.toast} role="status">
-      {toast.message}
-    </div>
-  );
+  return <div className={styles.toast}>{toast.message}</div>;
 };
 
 /**
  * 전역 토스트 뷰포트. 루트 레이아웃에 한 번만 마운트한다.
  * showToast() 로 띄운 메시지를 화면 하단에 잠시 노출하고 자동으로 사라진다.
  * 모듈 스코프 스토어를 구독하므로 화면 전환 후에도 메시지가 유지된다.
+ *
+ * 접근성: aria-live 영역(뷰포트)을 비어 있어도 항상 DOM 에 유지한다. 스크린리더가 영역을 미리
+ * 관찰하고 있어야 이후 삽입되는 토스트를 안정적으로 읽어주기 때문이다(영역과 내용을 동시에 마운트하면
+ * 첫 토스트가 안내되지 않을 수 있음). live region 은 이 뷰포트 한 곳에만 둔다 — 각 행에 role="status"
+ * 를 또 붙이면 polite live region 이 중첩돼 이중 안내가 날 수 있어 붙이지 않는다.
  */
 export const Toaster = () => {
   const toasts = useSyncExternalStore(subscribeToasts, getToastsSnapshot, getToastsSnapshot);
-
-  if (toasts.length === 0) {
-    return null;
-  }
 
   return (
     <div className={styles.viewport} aria-live="polite">

--- a/src/components/ui/Toast/Toaster.tsx
+++ b/src/components/ui/Toast/Toaster.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { dismissToast, getToastsSnapshot, subscribeToasts, type ToastItem } from './toastStore';
+import styles from './Toaster.module.scss';
+
+const ToastRow = ({ toast }: { toast: ToastItem }) => {
+  // 각 토스트는 마운트 시점에 자신의 자동 dismiss 타이머를 건다(언마운트 시 정리).
+  useEffect(() => {
+    const timer = setTimeout(() => dismissToast(toast.id), toast.duration);
+    return () => clearTimeout(timer);
+  }, [toast.id, toast.duration]);
+
+  return (
+    <div className={styles.toast} role="status">
+      {toast.message}
+    </div>
+  );
+};
+
+/**
+ * 전역 토스트 뷰포트. 루트 레이아웃에 한 번만 마운트한다.
+ * showToast() 로 띄운 메시지를 화면 하단에 잠시 노출하고 자동으로 사라진다.
+ * 모듈 스코프 스토어를 구독하므로 화면 전환 후에도 메시지가 유지된다.
+ */
+export const Toaster = () => {
+  const toasts = useSyncExternalStore(subscribeToasts, getToastsSnapshot, getToastsSnapshot);
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.viewport} aria-live="polite">
+      {toasts.map(toast => (
+        <ToastRow key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/ui/Toast/__tests__/toastStore.test.ts
+++ b/src/components/ui/Toast/__tests__/toastStore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { showToast, dismissToast, getToastsSnapshot, subscribeToasts } from '../toastStore';
+
+// toastStore 는 모듈 스코프 상태를 갖는다. 매 테스트 전에 남은 토스트를 비우고,
+// 구독한 리스너는 테스트 후 해제해 테스트 간 격리를 보장한다.
+describe('toastStore', () => {
+  const unsubscribers: Array<() => void> = [];
+
+  const subscribe = (listener: () => void) => {
+    const unsubscribe = subscribeToasts(listener);
+    unsubscribers.push(unsubscribe);
+    return unsubscribe;
+  };
+
+  beforeEach(() => {
+    for (const toast of getToastsSnapshot()) {
+      dismissToast(toast.id);
+    }
+  });
+
+  afterEach(() => {
+    while (unsubscribers.length > 0) {
+      unsubscribers.pop()?.();
+    }
+  });
+
+  it('showToast 는 토스트를 추가하고 증가하는 id 를 반환한다', () => {
+    const id1 = showToast('a');
+    const id2 = showToast('b');
+
+    expect(id2).toBe(id1 + 1);
+    expect(getToastsSnapshot().map(toast => toast.message)).toEqual(['a', 'b']);
+  });
+
+  it('dismissToast 는 해당 토스트를 제거하고 구독자에게 알린다', () => {
+    const id = showToast('a');
+    const listener = vi.fn();
+    subscribe(listener);
+
+    dismissToast(id);
+
+    expect(getToastsSnapshot()).toEqual([]);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  // useSyncExternalStore 무한 렌더 방지의 핵심 불변식:
+  // 변화가 없으면 스냅샷이 동일 참조여야 하고 구독자에게 알리지 않아야 한다.
+  it('존재하지 않는 id 를 dismiss 하면 동일 배열 참조를 유지하고 알리지 않는다', () => {
+    showToast('a');
+    const before = getToastsSnapshot();
+    const listener = vi.fn();
+    subscribe(listener);
+
+    dismissToast(999999);
+
+    expect(getToastsSnapshot()).toBe(before);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('변화가 없으면 getToastsSnapshot 은 동일 참조를 반환한다', () => {
+    expect(getToastsSnapshot()).toBe(getToastsSnapshot());
+  });
+
+  it('스택 상한(3)을 초과하면 가장 오래된 토스트를 버린다', () => {
+    showToast('1');
+    showToast('2');
+    showToast('3');
+    showToast('4');
+
+    const messages = getToastsSnapshot().map(toast => toast.message);
+    expect(messages).toEqual(['2', '3', '4']);
+    expect(messages.length).toBeLessThanOrEqual(3);
+  });
+
+  it('구독 해제 후에는 알림을 받지 않는다', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribe(listener);
+
+    showToast('a');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    showToast('b');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('duration 미지정 시 기본값(4000ms)을 사용한다', () => {
+    showToast('a');
+    showToast('b', 5000);
+
+    const [first, second] = getToastsSnapshot();
+    expect(first.duration).toBe(4000);
+    expect(second.duration).toBe(5000);
+  });
+});

--- a/src/components/ui/Toast/index.ts
+++ b/src/components/ui/Toast/index.ts
@@ -1,0 +1,3 @@
+export { Toaster } from './Toaster';
+export { showToast, dismissToast } from './toastStore';
+export type { ToastItem } from './toastStore';

--- a/src/components/ui/Toast/toastStore.ts
+++ b/src/components/ui/Toast/toastStore.ts
@@ -1,0 +1,48 @@
+// 전역 토스트 스토어 — 외부 의존성 없이 React 내장 useSyncExternalStore 로 구독한다.
+// 화면 전환(router.push)으로 호출부 컴포넌트가 언마운트돼도 토스트가 유지되도록, Toaster 는
+// 루트 레이아웃에 한 번만 마운트해 두고 여기(모듈 스코프)의 상태를 구독한다.
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  duration: number;
+}
+
+type Listener = () => void;
+
+// 메시지를 읽을 시간 확보 + 화면 전환 직후에도 잠시 보이도록 기본값을 넉넉히 둔다.
+const DEFAULT_DURATION_MS = 3000;
+
+let toasts: ToastItem[] = [];
+const listeners = new Set<Listener>();
+let nextId = 0;
+
+const emit = () => {
+  listeners.forEach(listener => listener());
+};
+
+export const subscribeToasts = (listener: Listener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+// 변경이 있을 때만 새 배열로 교체하므로 동일 참조가 유지된다
+// (useSyncExternalStore 가 불필요하게 재렌더하지 않도록). 서버 스냅샷도 동일하게 사용.
+export const getToastsSnapshot = (): ToastItem[] => toasts;
+
+export const showToast = (message: string, duration: number = DEFAULT_DURATION_MS): number => {
+  const id = nextId++;
+  toasts = [...toasts, { id, message, duration }];
+  emit();
+  return id;
+};
+
+export const dismissToast = (id: number): void => {
+  const next = toasts.filter(toast => toast.id !== id);
+  if (next.length !== toasts.length) {
+    toasts = next;
+    emit();
+  }
+};

--- a/src/components/ui/Toast/toastStore.ts
+++ b/src/components/ui/Toast/toastStore.ts
@@ -11,7 +11,11 @@ export interface ToastItem {
 type Listener = () => void;
 
 // 메시지를 읽을 시간 확보 + 화면 전환 직후에도 잠시 보이도록 기본값을 넉넉히 둔다.
-const DEFAULT_DURATION_MS = 3000;
+// (느린 사용자도 읽을 수 있게 4초 — 토스트는 화면 전환 후에도 유지되므로 목적지에서도 잠시 보인다.)
+const DEFAULT_DURATION_MS = 4000;
+
+// 동시에 쌓이는 토스트 상한. 초과 시 가장 오래된 것부터 버려 화면을 덮지 않게 한다.
+const MAX_TOASTS = 3;
 
 let toasts: ToastItem[] = [];
 const listeners = new Set<Listener>();
@@ -34,7 +38,8 @@ export const getToastsSnapshot = (): ToastItem[] => toasts;
 
 export const showToast = (message: string, duration: number = DEFAULT_DURATION_MS): number => {
   const id = nextId++;
-  toasts = [...toasts, { id, message, duration }];
+  const next = [...toasts, { id, message, duration }];
+  toasts = next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
   emit();
   return id;
 };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,4 +2,5 @@ export * from './Button';
 export * from './ConfirmDialog';
 export * from './Icon';
 export * from './TextField';
+export * from './Toast';
 export * from './TopNavigation';

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -101,6 +101,11 @@ export const ENV = {
   // 에러 웹훅 (서버 전용 시크릿). 미설정 시 /api/client-error 가 no-op — Sentry 와 병행 sink.
   DISCORD_ERROR_WEBHOOK_URL: process.env.DISCORD_ERROR_WEBHOOK_URL ?? '',
 
+  // 광고 (Google Ad Manager) — rewarded 광고 단위 경로 `/<networkCode>/<code>` 구성용 네트워크 코드.
+  // 미설정 시 광고 비활성화 → showRewardedAd 가 'unavailable' 반환(광고 없이 정상 진행).
+  // NEXT_PUBLIC_* 라 클라 번들에 inline → CI 빌드 env 주입 필요(런타임 wrangler var 아님).
+  GAM_NETWORK_CODE: process.env.NEXT_PUBLIC_GAM_NETWORK_CODE ?? '',
+
   // Firebase RemoteConfig (Web 신설, prod 환경만 활성화)
   // 키 미설정 시 SDK init 자체를 silent skip — `useRemoteConfig` 가 defaultValue 그대로 반환.
   FIREBASE_API_KEY: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? '',

--- a/src/features/academic/components/progress/GraduationProgressContent.module.scss
+++ b/src/features/academic/components/progress/GraduationProgressContent.module.scss
@@ -5,9 +5,9 @@
   display: flex;
   flex-direction: column;
   padding: spacing.$space-20;
+  margin-bottom: spacing.$space-40;
 
   @include device.compact {
     padding: spacing.$space-16;
   }
-  margin-bottom: spacing.$space-40;
 }

--- a/src/features/ads/adUnits.ts
+++ b/src/features/ads/adUnits.ts
@@ -1,0 +1,10 @@
+import { ENV } from '@/config/environment';
+
+// GAM 광고 단위 코드 — 대시보드 Ad unit 의 'Code' 와 정확히 일치해야 한다.
+const REWARDED_RESYNC_CODE = 'cchaksa_resync_rewarded';
+
+// 광고 단위 경로 `/<networkCode>/<code>`.
+// 네트워크 코드(NEXT_PUBLIC_GAM_NETWORK_CODE) 미설정 시 null → 광고 비활성(showRewardedAd 가 'unavailable').
+export const AD_UNITS = {
+  RESYNC_REWARDED: ENV.GAM_NETWORK_CODE ? `/${ENV.GAM_NETWORK_CODE}/${REWARDED_RESYNC_CODE}` : null,
+} as const;

--- a/src/features/ads/useRewardedAdGate.tsx
+++ b/src/features/ads/useRewardedAdGate.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { captureException } from '@sentry/nextjs';
+import { AD_UNITS } from './adUnits';
+
+// 광고 시청 결과.
+// - granted     : 광고를 끝까지 봐서 보상 획득 → 연동 진행
+// - dismissed   : 광고가 떠 있었으나 사용자가 거부/중단 → 보상 미획득 → 연동 진행하지 않음
+// - unavailable : 광고 자체가 없음(미설정/미충전/GPT 미로드) → 막을 수 없으니 그대로 진행
+export type RewardedResult = 'granted' | 'dismissed' | 'unavailable';
+
+// 광고가 '준비(rewardedSlotReady)'될 때까지 대기 한도. 초과 시(충전 실패 등) unavailable 로 보고 진행.
+const READY_TIMEOUT_MS = 5000;
+
+// --- 최소 GPT(Google Publisher Tag) 타입 (사용하는 표면만) ---
+interface RewardedSlot {
+  addService: (service: PubAdsService) => RewardedSlot;
+}
+interface RewardedEvent {
+  slot: RewardedSlot;
+  makeRewardedVisible: () => void;
+  payload?: { reward: number; type: string };
+}
+type RewardedListener = (event: RewardedEvent) => void;
+interface PubAdsService {
+  addEventListener: (type: string, listener: RewardedListener) => void;
+  removeEventListener: (type: string, listener: RewardedListener) => void;
+}
+interface Googletag {
+  cmd: { push: (fn: () => void) => void };
+  pubads: () => PubAdsService;
+  enableServices: () => void;
+  display: (slot: RewardedSlot) => void;
+  destroySlots: (slots: RewardedSlot[]) => void;
+  defineOutOfPageSlot: (adUnitPath: string, format: number) => RewardedSlot | null;
+  enums: { OutOfPageFormat: { REWARDED: number } };
+}
+type GoogletagWindow = Window & { googletag?: Googletag };
+
+// GPT 스크립트(gpt.js)가 아직 로드 전이면 명령 큐(stub)만 보장한다.
+// gpt.js 가 끝내 로드되지 않으면 cmd 콜백이 안 돌므로, 호출부의 READY_TIMEOUT 가 unavailable 로 회수.
+const getGoogletag = (): Googletag | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const w = window as GoogletagWindow;
+  w.googletag = w.googletag ?? ({ cmd: [] } as unknown as Googletag);
+  return w.googletag.cmd ? w.googletag : null;
+};
+
+/**
+ * 홈 갱신하기 → 보상형 광고 게이트 훅 (브라우저 전용).
+ * - showRewardedAd(): 광고를 요청하고, 준비되면 opt-in 다이얼로그를 띄운 뒤 결과를 Promise 로 반환.
+ * - optInDialog: 동의 UI props (ConfirmDialog 에 그대로 spread).
+ * 앱(웹뷰)에선 호출하지 않는다 — 앱은 네이티브 AdMob 책임.
+ */
+export function useRewardedAdGate() {
+  const [isOpen, setIsOpen] = useState(false);
+  // accept/decline 핸들러가 진행 중 광고의 상태에 접근하기 위한 브릿지.
+  const settleRef = useRef<((result: RewardedResult) => void) | null>(null);
+  const makeVisibleRef = useRef<(() => void) | null>(null);
+
+  const showRewardedAd = useCallback((): Promise<RewardedResult> => {
+    return new Promise<RewardedResult>(resolve => {
+      const adUnitPath = AD_UNITS.RESYNC_REWARDED;
+      const googletag = getGoogletag();
+      if (!adUnitPath || !googletag) {
+        resolve('unavailable');
+        return;
+      }
+
+      let settled = false;
+      let slot: RewardedSlot | null = null;
+      let granted = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let teardown: (() => void) | null = null;
+
+      const settle = (result: RewardedResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+        teardown?.();
+        teardown = null;
+        if (slot) {
+          try {
+            googletag.destroySlots([slot]);
+          } catch (error) {
+            captureException(error);
+          }
+          slot = null;
+        }
+        makeVisibleRef.current = null;
+        settleRef.current = null;
+        setIsOpen(false);
+        resolve(result);
+      };
+      settleRef.current = settle;
+
+      // 준비될 때까지의 대기만 가드. 광고가 떠서 시청이 시작되면(onReady) 해제한다.
+      timer = setTimeout(() => settle('unavailable'), READY_TIMEOUT_MS);
+
+      googletag.cmd.push(() => {
+        if (settled) {
+          return;
+        }
+        try {
+          slot = googletag.defineOutOfPageSlot(adUnitPath, googletag.enums.OutOfPageFormat.REWARDED);
+        } catch (error) {
+          captureException(error);
+          settle('unavailable');
+          return;
+        }
+        if (!slot) {
+          settle('unavailable');
+          return;
+        }
+
+        const definedSlot = slot;
+        const pubads = googletag.pubads();
+        definedSlot.addService(pubads);
+
+        const onReady = (event: RewardedEvent) => {
+          if (event.slot !== definedSlot) {
+            return;
+          }
+          if (timer) {
+            clearTimeout(timer);
+            timer = undefined;
+          }
+          // 동의(accept) 후에만 노출 — opt-in 필수(정책).
+          makeVisibleRef.current = () => {
+            try {
+              event.makeRewardedVisible();
+            } catch (error) {
+              captureException(error);
+              settle('unavailable');
+            }
+          };
+          setIsOpen(true);
+        };
+        const onGranted = (event: RewardedEvent) => {
+          if (event.slot === definedSlot) {
+            granted = true;
+          }
+        };
+        const onClosed = (event: RewardedEvent) => {
+          if (event.slot === definedSlot) {
+            settle(granted ? 'granted' : 'dismissed');
+          }
+        };
+
+        teardown = () => {
+          pubads.removeEventListener('rewardedSlotReady', onReady);
+          pubads.removeEventListener('rewardedSlotGranted', onGranted);
+          pubads.removeEventListener('rewardedSlotClosed', onClosed);
+        };
+        pubads.addEventListener('rewardedSlotReady', onReady);
+        pubads.addEventListener('rewardedSlotGranted', onGranted);
+        pubads.addEventListener('rewardedSlotClosed', onClosed);
+
+        googletag.enableServices();
+        googletag.display(definedSlot);
+      });
+    });
+  }, []);
+
+  // 동의: 광고 노출. 결과(granted/dismissed)는 GPT 이벤트로 settle.
+  const acceptOptIn = useCallback(() => {
+    setIsOpen(false);
+    makeVisibleRef.current?.();
+  }, []);
+
+  // 거부(취소/오버레이/ESC): 보상 미획득 → dismissed.
+  const declineOptIn = useCallback(() => {
+    settleRef.current?.('dismissed');
+  }, []);
+
+  const optInDialog = {
+    isOpen,
+    title: '광고 시청 후 업데이트',
+    message: '짧은 광고를 끝까지 본 뒤\n최신 학업 정보로 업데이트돼요.',
+    confirmText: '광고 보고 업데이트',
+    cancelText: '취소',
+    onConfirm: acceptOptIn,
+    onClose: declineOptIn,
+  };
+
+  return { showRewardedAd, optInDialog };
+}

--- a/src/features/ads/useRewardedAdGate.tsx
+++ b/src/features/ads/useRewardedAdGate.tsx
@@ -200,9 +200,9 @@ export function useRewardedAdGate() {
 
   const optInDialog = {
     isOpen,
-    title: '광고 시청 후 업데이트',
-    message: '짧은 광고를 끝까지 본 뒤\n최신 학업 정보로 업데이트돼요.',
-    confirmText: '광고 보고 업데이트',
+    title: '안내',
+    message: '척척학사를 위한 짧은 광고가 재생된 후,\n최신 학업 정보 업데이트 화면으로 이동합니다.',
+    confirmText: '확인',
     cancelText: '취소',
     onConfirm: acceptOptIn,
     onClose: declineOptIn,

--- a/src/features/ads/useRewardedAdGate.tsx
+++ b/src/features/ads/useRewardedAdGate.tsx
@@ -7,8 +7,10 @@ import { AD_UNITS } from './adUnits';
 // 광고 시청 결과.
 // - granted     : 광고를 끝까지 봐서 보상 획득 → 연동 진행
 // - dismissed   : 광고가 떠 있었으나 사용자가 거부/중단 → 보상 미획득 → 연동 진행하지 않음
-// - unavailable : 광고 자체가 없음(미설정/미충전/GPT 미로드) → 막을 수 없으니 그대로 진행
-export type RewardedResult = 'granted' | 'dismissed' | 'unavailable';
+// - exhausted   : 이 페이지에서 광고를 이미 한 번 소진(GPT 는 페이지당 rewarded 1개) → 새 슬롯이 null.
+//                 우회(취소→재클릭→통과) 방지 위해 진행하지 않고, 새로고침 안내로 재장전 유도.
+// - unavailable : 광고 자체가 없음(미설정/미충전/GPT 미로드, 아직 한 번도 안 뜸) → 막을 수 없으니 진행
+export type RewardedResult = 'granted' | 'dismissed' | 'unavailable' | 'exhausted';
 
 // 광고가 '준비(rewardedSlotReady)'될 때까지 대기 한도. 초과 시(충전 실패 등) unavailable 로 보고 진행.
 const READY_TIMEOUT_MS = 5000;
@@ -49,6 +51,12 @@ const getGoogletag = (): Googletag | null => {
   return w.googletag.cmd ? w.googletag : null;
 };
 
+// GPT 제약: 페이지 1회 로드당 rewarded 광고 1개만 가능. 한 번 광고가 떴다 닫히면(취소 포함) 같은
+// 페이지에선 두 번째 defineOutOfPageSlot 가 null 로 떨어진다 → 새로고침 전까지 재시청 불가.
+// "이미 소진(exhausted)" 을 "광고 인프라 없음(unavailable)" 과 구분해, 취소→재클릭 우회를 막는다.
+// 모듈 스코프 = 페이지 로드 단위 수명(SPA 클라 네비게이션으론 리셋 안 됨 — GPT 제약과 일치).
+let adOfferedThisPageView = false;
+
 /**
  * 홈 갱신하기 → 보상형 광고 게이트 훅 (브라우저 전용).
  * - showRewardedAd(): 광고를 요청하고, 준비되면 opt-in 다이얼로그를 띄운 뒤 결과를 Promise 로 반환.
@@ -63,6 +71,12 @@ export function useRewardedAdGate() {
 
   const showRewardedAd = useCallback((): Promise<RewardedResult> => {
     return new Promise<RewardedResult>(resolve => {
+      // 이미 이 페이지에서 rewarded 를 한 번 띄웠으면 GPT 제약상 새 광고 불가(페이지당 1개).
+      // 슬롯 생성·5초 READY_TIMEOUT 을 거치지 않고 즉시 exhausted 로 반환(재클릭 지연 제거).
+      if (adOfferedThisPageView) {
+        resolve('exhausted');
+        return;
+      }
       const adUnitPath = AD_UNITS.RESYNC_REWARDED;
       const googletag = getGoogletag();
       if (!adUnitPath || !googletag) {
@@ -102,7 +116,8 @@ export function useRewardedAdGate() {
       settleRef.current = settle;
 
       // 준비될 때까지의 대기만 가드. 광고가 떠서 시청이 시작되면(onReady) 해제한다.
-      timer = setTimeout(() => settle('unavailable'), READY_TIMEOUT_MS);
+      // 한 번이라도 광고가 떴던 페이지면 'exhausted'(진행X), 아니면 'unavailable'(진행O).
+      timer = setTimeout(() => settle(adOfferedThisPageView ? 'exhausted' : 'unavailable'), READY_TIMEOUT_MS);
 
       googletag.cmd.push(() => {
         if (settled) {
@@ -116,7 +131,8 @@ export function useRewardedAdGate() {
           return;
         }
         if (!slot) {
-          settle('unavailable');
+          // 2번째 클릭 등 — 이미 이 페이지에서 rewarded 소진됨 → null. 우회 방지 위해 exhausted.
+          settle(adOfferedThisPageView ? 'exhausted' : 'unavailable');
           return;
         }
 
@@ -128,6 +144,8 @@ export function useRewardedAdGate() {
           if (event.slot !== definedSlot) {
             return;
           }
+          // 광고가 실제로 떴음 — 이후 같은 페이지의 재요청은 exhausted 로 처리(우회 차단).
+          adOfferedThisPageView = true;
           if (timer) {
             clearTimeout(timer);
             timer = undefined;

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.module.scss
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.module.scss
@@ -11,3 +11,20 @@
 .text {
   color: colors.$gray-600;
 }
+
+.iconWrap {
+  display: inline-flex;
+  align-items: center;
+}
+
+// 광고 슬롯 준비(최대 5초)/요청 진행 동안 회전시켜 "처리 중"임을 알린다.
+// 로딩 피드백은 필수 정보이므로 prefers-reduced-motion 으로 끄지 않는다(대신 aria-busy 로도 전달).
+.spinning {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -23,6 +23,7 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
   const router = useInternalRouter();
   const { showRewardedAd, optInDialog } = useRewardedAdGate();
   const [isRequesting, setIsRequesting] = useState(false);
+  const [reloadPromptOpen, setReloadPromptOpen] = useState(false);
   const parsedLastSyncedAt = data.lastSyncedAt ? parseISO(data.lastSyncedAt) : null;
   const formattedLastSyncedAt =
     parsedLastSyncedAt && isValid(parsedLastSyncedAt) ? format(parsedLastSyncedAt, 'yy년 M월 d일 HH:mm') : '';
@@ -40,11 +41,17 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
     setIsRequesting(true);
     try {
       const result = await showRewardedAd();
-      // 광고가 떠 있었는데 거부/중단('dismissed')하면 보상 미획득 → 연동 진행하지 않음(홈 유지).
-      // 광고 자체가 없으면('unavailable') 막을 수 없으니 그대로 진행.
+      // dismissed: 광고 떴는데 거부/중단 → 보상 미획득 → 진행하지 않음(홈 유지).
       if (result === 'dismissed') {
         return;
       }
+      // exhausted: 이 페이지에서 광고 이미 소진(GPT 페이지당 1개) → 우회 방지 위해 진행하지 않고
+      //            새로고침 안내(reload 시 새 광고 1개 재장전).
+      if (result === 'exhausted') {
+        setReloadPromptOpen(true);
+        return;
+      }
+      // granted(시청 완료) | unavailable(광고 자체가 없음) → 진행.
       router.push(ROUTES.RESYNC.LOGIN);
     } finally {
       setIsRequesting(false);
@@ -63,6 +70,15 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
         <Icon name="refresh" size={16} />
       </button>
       <ConfirmDialog {...optInDialog} />
+      <ConfirmDialog
+        isOpen={reloadPromptOpen}
+        title="광고 시청이 필요해요"
+        message={'학업 정보 업데이트는 광고 시청 후 진행돼요.\n새로고침하고 다시 시도해주세요.'}
+        confirmText="새로고침"
+        cancelText="닫기"
+        onConfirm={() => window.location.reload()}
+        onClose={() => setReloadPromptOpen(false)}
+      />
     </>
   );
 };

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -5,8 +5,9 @@ import clsx from 'clsx';
 import { format } from 'date-fns/format';
 import { isValid } from 'date-fns/isValid';
 import { parseISO } from 'date-fns/parseISO';
-import { Icon, showToast } from '@/components/ui';
+import { Icon } from '@/components/ui';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { showToast } from '@/components/ui/Toast';
 import { ROUTES } from '@/constants';
 import { useRewardedAdGate } from '@/features/ads/useRewardedAdGate';
 import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
@@ -89,9 +90,12 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
         className={clsx(styles.container, styles.text, '--body-sm-medium')}
         onClick={handleResyncLogin}
         disabled={isRequesting}
+        aria-busy={isRequesting}
       >
         {formattedLastSyncedAt ? `${formattedLastSyncedAt} 업데이트` : '정보 업데이트'}
-        <Icon name="refresh" size={16} />
+        <span className={clsx(styles.iconWrap, isRequesting && styles.spinning)}>
+          <Icon name="refresh" size={16} />
+        </span>
       </button>
       <ConfirmDialog {...optInDialog} />
     </>

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { format } from 'date-fns/format';
 import { isValid } from 'date-fns/isValid';
 import { parseISO } from 'date-fns/parseISO';
-import { Icon } from '@/components/ui';
+import { Icon, showToast } from '@/components/ui';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { ROUTES } from '@/constants';
 import { useRewardedAdGate } from '@/features/ads/useRewardedAdGate';
@@ -56,7 +56,13 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
         window.location.reload();
         return;
       }
-      // granted(시청 완료) | unavailable(광고 자체가 없음) → 진행.
+      // granted(시청 완료) → 토스트 없이 바로 진행.
+      // unavailable: 광고 매체가 광고를 안 주거나(no-fill) 네트워크 문제 등으로 노출 실패 → 막을 수 없으니
+      //              안내 토스트를 띄우고 학업 정보 업데이트 화면으로 진행. 토스트는 전역(루트 레이아웃)
+      //              이라 화면 전환 후에도 잠시 유지된다.
+      if (result === 'unavailable') {
+        showToast('지금은 광고가 없어 바로 학업 정보 업데이트 화면으로 이동합니다.');
+      }
       router.push(ROUTES.RESYNC.LOGIN);
     } finally {
       setIsRequesting(false);

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useState } from 'react';
 import clsx from 'clsx';
 import { format } from 'date-fns/format';
 import { isValid } from 'date-fns/isValid';
 import { parseISO } from 'date-fns/parseISO';
 import { Icon } from '@/components/ui';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { ROUTES } from '@/constants';
+import { useRewardedAdGate } from '@/features/ads/useRewardedAdGate';
 import { useProfileQuery } from '@/features/dashboard/apis/queries/useProfileQuery';
 import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { EVENTS, track } from '@/lib/analytics';
@@ -18,24 +21,49 @@ interface SyncUpdateButtonProps {
 const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
   const { data } = useProfileQuery();
   const router = useInternalRouter();
+  const { showRewardedAd, optInDialog } = useRewardedAdGate();
+  const [isRequesting, setIsRequesting] = useState(false);
   const parsedLastSyncedAt = data.lastSyncedAt ? parseISO(data.lastSyncedAt) : null;
   const formattedLastSyncedAt =
     parsedLastSyncedAt && isValid(parsedLastSyncedAt) ? format(parsedLastSyncedAt, 'yy년 M월 d일 HH:mm') : '';
 
-  const handleResyncLogin = () => {
+  const handleResyncLogin = async () => {
     track(EVENTS.HOME_UNIV_RESYNC_BTN_TAP);
+    // 앱(웹뷰): 네이티브에 위임 — 광고는 네이티브 AdMob 책임이라 여기선 끼우지 않는다.
     if (onNavigate) {
       onNavigate();
       return;
     }
-    router.push(ROUTES.RESYNC.LOGIN);
+    if (isRequesting) {
+      return;
+    }
+    setIsRequesting(true);
+    try {
+      const result = await showRewardedAd();
+      // 광고가 떠 있었는데 거부/중단('dismissed')하면 보상 미획득 → 연동 진행하지 않음(홈 유지).
+      // 광고 자체가 없으면('unavailable') 막을 수 없으니 그대로 진행.
+      if (result === 'dismissed') {
+        return;
+      }
+      router.push(ROUTES.RESYNC.LOGIN);
+    } finally {
+      setIsRequesting(false);
+    }
   };
 
   return (
-    <button className={clsx(styles.container, styles.text, '--body-sm-medium')} onClick={handleResyncLogin}>
-      {formattedLastSyncedAt ? `${formattedLastSyncedAt} 업데이트` : '정보 업데이트'}
-      <Icon name="refresh" size={16} />
-    </button>
+    <>
+      <button
+        type="button"
+        className={clsx(styles.container, styles.text, '--body-sm-medium')}
+        onClick={handleResyncLogin}
+        disabled={isRequesting}
+      >
+        {formattedLastSyncedAt ? `${formattedLastSyncedAt} 업데이트` : '정보 업데이트'}
+        <Icon name="refresh" size={16} />
+      </button>
+      <ConfirmDialog {...optInDialog} />
+    </>
   );
 };
 

--- a/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
+++ b/src/features/dashboard/components/SyncUpdateButton/SyncUpdateButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { format } from 'date-fns/format';
 import { isValid } from 'date-fns/isValid';
@@ -18,17 +18,21 @@ interface SyncUpdateButtonProps {
   onNavigate?: () => void;
 }
 
+// 자동 재개 플래그(sessionStorage). GPT 는 페이지당 rewarded 1개라, 광고가 한 번 소진되면 새 광고는
+// reload 후에만 가능. exhausted 시 이 플래그를 세우고 reload → 재로드 후 마운트에서 광고 흐름을
+// 자동 재개해 "수동 새로고침" 불편을 없앤다(게이트는 유지 — reload 후에도 광고를 봐야 진행).
+const RESUME_AD_KEY = 'resync:resumeAd';
+
 const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
   const { data } = useProfileQuery();
   const router = useInternalRouter();
   const { showRewardedAd, optInDialog } = useRewardedAdGate();
   const [isRequesting, setIsRequesting] = useState(false);
-  const [reloadPromptOpen, setReloadPromptOpen] = useState(false);
   const parsedLastSyncedAt = data.lastSyncedAt ? parseISO(data.lastSyncedAt) : null;
   const formattedLastSyncedAt =
     parsedLastSyncedAt && isValid(parsedLastSyncedAt) ? format(parsedLastSyncedAt, 'yy년 M월 d일 HH:mm') : '';
 
-  const handleResyncLogin = async () => {
+  const handleResyncLogin = useCallback(async () => {
     track(EVENTS.HOME_UNIV_RESYNC_BTN_TAP);
     // 앱(웹뷰): 네이티브에 위임 — 광고는 네이티브 AdMob 책임이라 여기선 끼우지 않는다.
     if (onNavigate) {
@@ -45,10 +49,11 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
       if (result === 'dismissed') {
         return;
       }
-      // exhausted: 이 페이지에서 광고 이미 소진(GPT 페이지당 1개) → 우회 방지 위해 진행하지 않고
-      //            새로고침 안내(reload 시 새 광고 1개 재장전).
+      // exhausted: 이 페이지에서 광고 이미 소진(GPT 페이지당 1개) → 우회 방지 + 수동 새로고침 제거 위해
+      //            의도를 기억하고 자동 reload → 재로드 후 아래 useEffect 가 광고 흐름을 자동 재개.
       if (result === 'exhausted') {
-        setReloadPromptOpen(true);
+        sessionStorage.setItem(RESUME_AD_KEY, '1');
+        window.location.reload();
         return;
       }
       // granted(시청 완료) | unavailable(광고 자체가 없음) → 진행.
@@ -56,7 +61,20 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
     } finally {
       setIsRequesting(false);
     }
-  };
+  }, [onNavigate, isRequesting, showRewardedAd, router]);
+
+  // 자동 재개: exhausted 로 reload 된 경우, 재로드 후 광고 흐름을 한 번 자동 시작(수동 새로고침 불필요).
+  // 플래그를 즉시 지워 멱등 — handleResyncLogin 재생성으로 effect 가 재실행돼도 1회만 동작.
+  // 앱 경로(onNavigate)에선 자동 재개하지 않는다(웹 전용).
+  useEffect(() => {
+    if (typeof window === 'undefined' || onNavigate) {
+      return;
+    }
+    if (sessionStorage.getItem(RESUME_AD_KEY) === '1') {
+      sessionStorage.removeItem(RESUME_AD_KEY);
+      void handleResyncLogin();
+    }
+  }, [handleResyncLogin, onNavigate]);
 
   return (
     <>
@@ -70,15 +88,6 @@ const SyncUpdateButton = ({ onNavigate }: SyncUpdateButtonProps = {}) => {
         <Icon name="refresh" size={16} />
       </button>
       <ConfirmDialog {...optInDialog} />
-      <ConfirmDialog
-        isOpen={reloadPromptOpen}
-        title="광고 시청이 필요해요"
-        message={'학업 정보 업데이트는 광고 시청 후 진행돼요.\n새로고침하고 다시 시도해주세요.'}
-        confirmText="새로고침"
-        cancelText="닫기"
-        onConfirm={() => window.location.reload()}
-        onClose={() => setReloadPromptOpen(false)}
-      />
     </>
   );
 };


### PR DESCRIPTION
## 개요
홈 "갱신하기" 버튼을 **보상형 광고(GAM rewarded) 게이트** 뒤로 넣습니다. 광고를 끝까지 보면(`granted`) 포털 로그인(`/resync/login`)으로 진행합니다.

- **브라우저(`/main`) 전용**. 앱(`/mpa`)은 네이티브 AdMob 책임이라 손대지 않음(AdSense/GAM은 앱 WebView 정책 위반).

## 결과별 동작
| 결과 | 상황 | 동작 |
|---|---|---|
| `granted` | 광고 끝까지 시청 | `/resync/login` 진행 |
| `dismissed` | 광고 떴는데 거부/중단 | **연동 취소(홈 유지)** |
| `unavailable` | 광고 자체가 없음(미설정/미충전/GPT 미로드) | 진행 (광고 없는 걸로 막을 수 없음) |

## 변경
- `src/features/ads/useRewardedAdGate.tsx` 🆕 — GPT 보상형 out-of-page 슬롯 + opt-in 다이얼로그(`ConfirmDialog` 재사용)
- `src/features/ads/adUnits.ts` 🆕 — `NEXT_PUBLIC_GAM_NETWORK_CODE` 미설정 시 `null` → 광고 비활성(`unavailable`)
- `src/config/environment.ts` — `GAM_NETWORK_CODE` 추가
- `src/app/(main)/main/layout.tsx` — GPT 스크립트 로드(브라우저 `/main` 전용, `(mpa)` 격리)
- `SyncUpdateButton.tsx` — 웹 경로 게이트 연결 + 중복탭 가드

## ⚠️ 배포 전 필요 (이 PR 단독으론 광고 안 뜸)
1. **빌드 env 주입**: `deploy-cloudflare.yml`에 `NEXT_PUBLIC_GAM_NETWORK_CODE` 추가 필요(로컬 `.env`는 gitignore라 배포에 안 들어감). 미설정 시 항상 `unavailable` → 광고 없이 정상 진행.
2. **GAM**: 광고 단위 `cchaksa_resync_rewarded` 생성 + fill(테스트는 House/Reservation 라인아이템).

## 테스트
- env 없는 현재: `/main` → 업데이트 버튼 → `unavailable` → 바로 `/resync/login`(기능 정상).
- 광고 흐름: `NEXT_PUBLIC_GAM_NETWORK_CODE` 설정 + GAM 라인아이템 fill 후 opt-in→시청→진행 확인.
- type-check / lint 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
