### PR TITLE
chore(codex): 저장소 공용 워크플로 스킬 추가

### DIFF
--- a/.agents/skills/cchaksa-build-feature/SKILL.md
+++ b/.agents/skills/cchaksa-build-feature/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: cchaksa-build-feature
+description: Implement product features in the chukchuk-haksa repository from a natural-language specification. Use for new screens, user flows, API-backed features, WebView counterparts, mocks, or feature-level refactors that must follow this repository's architecture, generated API boundaries, routing conventions, and verification commands. Do not use for a narrow one-line fix or review-only request.
+---
+
+# 척척학사 기능 구현
+
+Implement a feature end to end while preserving the repository's established boundaries. Treat `AGENTS.md` and the current branch as the source of truth.
+
+## 1. Establish the contract
+
+1. Read `AGENTS.md`.
+2. Inspect the current branch and relevant routes, features, UI components, API clients, query keys, and tests.
+3. Convert the request into:
+   - confirmed product behavior;
+   - unresolved product or backend decisions;
+   - affected web and `/mpa/*` environments;
+   - observable completion criteria.
+4. Do not encode unresolved policy as permanent behavior. Isolate it behind a mock, callback, adapter, or clearly named provisional mapping.
+
+## 2. Choose ownership
+
+- Put domain-specific code under `src/features/<domain>/`.
+- Keep route composition in `src/app/`.
+- Reuse `src/components/ui/` before creating visual primitives.
+- Promote code to `src/shared/` only after two real consumers exist.
+- Use `ROUTES` and `useInternalRouter`; do not duplicate route strings.
+- Check for a corresponding `/mpa/*` flow before changing a web flow.
+
+Keep the runtime direction:
+
+```text
+page/component
+  → React Query hook
+  → feature service
+  → generated API client
+  → backend
+```
+
+## 3. Handle API readiness
+
+When the endpoint exists in OpenAPI:
+
+1. Regenerate with `yarn api:update`.
+2. Do not edit generated files manually.
+3. Normalize and validate responses in the feature service.
+
+When the endpoint is not yet in OpenAPI:
+
+1. Define feature-local domain types and runtime schemas.
+2. Add a service boundary matching the expected future generated client.
+3. Use MSW or a development-only fixture when interactive verification is needed.
+4. Keep mock code out of production behavior.
+5. Record assumptions that must be replaced after Swagger integration.
+
+## 4. Design state and failure behavior
+
+Explicitly decide:
+
+- server state versus local interaction state;
+- loading, empty, error, retry, and duplicate-submit behavior;
+- draft reset conditions when the target entity changes;
+- navigation and re-entry behavior;
+- WebView bridge fallback behavior;
+- mutation idempotency and transport retry constraints.
+
+Avoid dual sources of truth. For input-heavy screens, place state as close to the changing field as possible or use scoped subscriptions so unrelated layout does not rerender.
+
+## 5. Implement in vertical slices
+
+Build the smallest runnable path first:
+
+1. types/schema and pure transformations;
+2. state or query/service boundary;
+3. reusable feature components;
+4. route composition;
+5. mock/preview path if the real entry flow is unavailable;
+6. tests.
+
+Keep preview and debug routes development-only and verify they return 404 in a production build.
+
+## 6. Verify
+
+Run targeted checks while iterating, then:
+
+```bash
+yarn type-check
+yarn lint
+yarn test --run
+```
+
+Also run `yarn build` when changing routes, fonts, server/client boundaries, Next configuration, or production guards. Disable external artifact uploads locally rather than weakening production configuration.
+
+Report:
+
+- implemented behavior;
+- deferred backend/product decisions;
+- verification results;
+- existing unrelated warnings separately from new failures.

--- a/.agents/skills/cchaksa-build-feature/agents/openai.yaml
+++ b/.agents/skills/cchaksa-build-feature/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "척척학사 기능 구현"
+  short_description: "척척학사 기능을 저장소 규칙에 맞게 구현하고 검증"
+  default_prompt: "Use $cchaksa-build-feature to implement this feature according to the repository architecture and verification rules."

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: create-pr
+description: Prepare and create a GitHub pull request for the current repository. Use when the user asks to commit, push, open a PR, write a PR description, or share changes for team review. Inspect the actual diff, include only authorized files, run proportionate verification, push the branch, and create a clear Korean PR that an IT Meister high school student can understand. Do not merge the PR unless the user explicitly asks.
+---
+
+# PR 생성
+
+Create a reviewable pull request from the real branch state. Explain the change in simple Korean without hiding important technical facts.
+
+## 1. Check the working state
+
+1. Read `AGENTS.md` and repository Git rules.
+2. Inspect:
+   - current branch;
+   - target base branch;
+   - `git status`;
+   - staged and unstaged diffs;
+   - recent commit style;
+   - configured remote;
+   - repository PR template, if present.
+3. Preserve unrelated user changes.
+4. If the user asks for only certain files, stage and commit only those files.
+5. Never include secrets, local environment files, generated caches, or unrelated debug artifacts.
+
+If the current branch contains unrelated work, use a separate branch or worktree instead of stashing or overwriting the user's work.
+
+## 2. Verify before committing
+
+Choose checks based on the change:
+
+- documentation or skills: format, links, structure validator, and `git diff --check`;
+- frontend logic: type-check, lint, relevant tests;
+- routes, fonts, build configuration, or server/client boundaries: production build;
+- API changes: schema/type checks and relevant service tests.
+
+State which warnings existed before the change. Do not claim that a check passed if it was not run.
+
+## 3. Create the commit
+
+1. Review `git diff --cached --name-only`.
+2. Confirm every staged file belongs to the requested change.
+3. Use a Conventional Commit message:
+
+```text
+feat(scope): ...
+fix(scope): ...
+chore(scope): ...
+docs(scope): ...
+test(scope): ...
+```
+
+4. Commit only after the staged diff and verification are clean.
+
+## 4. Push safely
+
+- Push the current feature branch with upstream tracking.
+- Do not force-push unless the user explicitly authorizes it.
+- Do not push directly to protected branches such as `main` or `dev`.
+- Confirm the remote branch after pushing.
+
+## 5. Write an easy PR description
+
+Use short sentences and explain unfamiliar terms once. Prefer the background and solution process over a long file-by-file change list. Help the reviewer understand why the chosen approach is reasonable.
+
+Recommended structure:
+
+```markdown
+## 배경
+
+어떤 불편이나 반복 문제가 있었는지 설명합니다.
+지금 해결해야 하는 이유와 목표를 적습니다.
+
+## 해결 과정
+
+- 확인한 기존 구조와 제약
+- 검토한 방법과 선택한 방법
+- 그 방법을 선택한 이유
+- 구현하면서 함께 막은 실수나 위험
+
+## 결과
+
+- 최종적으로 가능해진 일
+- 핵심 변경 요약
+- 팀에 미치는 영향
+
+## 어떻게 사용하나요?
+
+명령어나 실제 사용 예시를 적습니다.
+
+## 확인한 내용
+
+- [x] 실행한 검사
+- [x] 테스트 또는 validator
+
+## 리뷰할 때 봐주세요
+
+- 팀원이 결정하거나 확인할 부분
+
+## 아직 하지 않은 것
+
+- 이번 PR 범위 밖의 작업이나 알려진 제한
+```
+
+Keep `결과` shorter than `배경` and `해결 과정` unless the change itself requires detailed migration instructions.
+
+For a repository skill PR, also explain:
+
+- what a Codex skill is;
+- where the skills are stored;
+- whether teammates need installation;
+- explicit invocation examples using `$skill-name`;
+- how to update and validate a skill;
+- what behavior remains controlled by `AGENTS.md`.
+
+## 6. Create and verify the PR
+
+1. Use `gh pr create` with the correct base and head.
+2. Avoid shell interpolation hazards when the body contains `$skill-name`; use a safely quoted temporary body file.
+3. Open or inspect the created PR with `gh pr view`.
+4. Return:
+   - branch name;
+   - commit hash and message;
+   - PR title and URL;
+   - verification results;
+   - any follow-up decision.
+
+Do not merge, add reviewers, labels, or assignees unless requested or required by an existing repository rule.

--- a/.agents/skills/create-pr/agents/openai.yaml
+++ b/.agents/skills/create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR 생성"
+  short_description: "변경사항을 검증하고 이해하기 쉬운 PR을 생성"
+  default_prompt: "Use $create-pr to verify the current branch and create a clear pull request for the team."

--- a/.agents/skills/figma-implement-ui/SKILL.md
+++ b/.agents/skills/figma-implement-ui/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: figma-implement-ui
+description: Implement or refine frontend UI from a Figma node in the chukchuk-haksa repository. Use when a request includes a Figma URL, screenshot comparison, typography or color-token matching, responsive card/layout behavior, interaction variants, or pixel-level visual corrections. Do not use when the task is only to edit the Figma file rather than implement code.
+---
+
+# Figma UI 구현
+
+Translate the design into maintainable responsive code. Treat the Figma node as evidence, not as a screenshot to approximate from memory.
+
+## 1. Collect evidence before coding
+
+1. Read `AGENTS.md` and inspect the target component and surrounding layout.
+2. Extract the exact Figma `fileKey` and `nodeId`.
+3. Retrieve design context, screenshot, variables, and component metadata when available.
+4. Inspect every relevant variant, not only the default state:
+   - selected and unselected;
+   - focus and input-active;
+   - grade/status/theme variants;
+   - long text and nullable data;
+   - compact and wider viewport behavior.
+5. If Figma access is rate-limited, state which values are verified and which remain provisional. Never present guessed values as confirmed tokens.
+
+## 2. Build a design evidence table
+
+Before implementation, map each important property to its source:
+
+| Property | Required evidence |
+| --- | --- |
+| Typography | Figma style name, family, weight, size, line height |
+| Color | variable/style or Selection color |
+| Spacing | measured gap/padding and parent alignment |
+| Sizing | fixed, min/max, fill, hug, or ratio behavior |
+| Radius/border | token or measured value |
+| Interaction | selected, focus, disabled, loading |
+
+Prefer repository tokens and mixins. If the design uses a missing reusable token, add it centrally with a clear name. Keep unverified variant mappings in one map so they can be replaced without editing components.
+
+## 3. Implement responsive intent
+
+- Reproduce the fixed dimensions that carry visual intent.
+- Use `width: 100%`, grid fractions, `min-height`, and max-width constraints where the design should expand.
+- Do not scale the whole card proportionally unless typography and controls are meant to scale too.
+- Keep section edges aligned to the same content column.
+- Let internal tag/input widths grow while preserving measured gaps.
+- Check long course names, wrapped tags, `score=null`, and narrow devices.
+- Account for safe areas and mobile keyboards when controls are fixed or sticky.
+
+## 4. Match typography and interaction
+
+- Load the actual font weights rather than relying on browser synthesis.
+- Apply the named Figma typography style through repository mixins.
+- Center tag labels both horizontally and vertically.
+- Map selected text, border, gradient, and focus colors by domain variant.
+- Add keyboard-visible focus states; do not remove outlines without an accessible replacement.
+- Preserve semantic fieldsets, legends, labels, button states, and live regions.
+
+## 5. Compare repeatedly
+
+Use this loop:
+
+1. implement one visual section;
+2. run the local page at the target viewport;
+3. capture or inspect a screenshot;
+4. compare outer geometry, section alignment, typography, colors, then micro-spacing;
+5. adjust tokens/layout;
+6. repeat at one narrow and one wide mobile viewport.
+
+Do not wait until the entire screen is finished before comparing.
+
+## 6. Verify code quality
+
+Check that:
+
+- styles live in colocated SCSS modules;
+- no duplicate magic values replace existing tokens;
+- dynamic values use data attributes or CSS variables cleanly;
+- input interactions do not rerender the entire screen unnecessarily;
+- preview/debug routes cannot ship as accessible production pages.
+
+Run targeted tests, type-check, lint, and build when fonts or route boundaries changed. Summarize verified Figma values separately from provisional mappings.

--- a/.agents/skills/figma-implement-ui/agents/openai.yaml
+++ b/.agents/skills/figma-implement-ui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Figma UI 구현"
+  short_description: "Figma를 토큰·반응형·스크린샷 기준으로 정확히 구현"
+  default_prompt: "Use $figma-implement-ui to implement this Figma screen accurately in the current codebase."

--- a/.agents/skills/review-frontend-change/SKILL.md
+++ b/.agents/skills/review-frontend-change/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: review-frontend-change
+description: Review current frontend changes in the chukchuk-haksa repository from product, architecture, React performance, accessibility, visual fidelity, API-contract, testing, mobile WebView, and operational perspectives. Use for pre-PR review, multi-perspective review, regression analysis, or requests to fix findings through a severity such as P1 or P2. When the user asks only for review, do not modify code; when they specify a fix threshold, implement and verify findings through that threshold.
+---
+
+# 프론트엔드 다관점 리뷰
+
+Produce an evidence-backed review rather than persona theater. Different perspectives are lenses over the same code, not invented quotations from named engineers.
+
+## 1. Determine review mode
+
+- **Review only:** inspect and report; do not edit.
+- **Fix through severity:** report findings, implement all findings at or above the requested threshold, then rerun verification.
+- **Unspecified:** default to review only.
+
+Review the working tree without overwriting unrelated user changes.
+
+## 2. Establish the change surface
+
+1. Read `AGENTS.md`.
+2. Inspect `git status`, diff, new files, relevant neighboring code, and tests.
+3. Identify the intended user flow and affected web/MPA routes.
+4. Distinguish new findings from pre-existing repository warnings.
+5. Reproduce or inspect the UI when visual or interaction behavior is material.
+
+## 3. Apply the review lenses
+
+### Product and flow
+
+- Does the implementation match confirmed behavior?
+- Are exit, re-entry, empty, loading, failure, and duplicate-submit states coherent?
+- Has an unresolved policy accidentally become permanent behavior?
+
+### Repository architecture
+
+- Is ownership correct between `app`, `features`, `shared`, and `components/ui`?
+- Are generated API boundaries preserved?
+- Are route constants, router abstractions, query keys, boundaries, and WebView contracts reused?
+- Is an abstraction genuinely shared, or prematurely generalized?
+
+### React and state
+
+- Is there one source of truth?
+- Are reset conditions tied to the actual target identity?
+- Do tag/input changes rerender only the required subtree?
+- Are memoization and external subscriptions correct rather than decorative?
+- Are callbacks, snapshots, and derived values referentially stable where required?
+
+### API and data integrity
+
+- Are runtime schemas consistent with backend policy?
+- Are nullable values preserved?
+- Are complete-set, uniqueness, target-semester, retry, and idempotency constraints represented?
+- Can mocks be replaced by generated clients without rewriting the UI?
+
+### Visual and responsive fidelity
+
+- Are typography, colors, spacing, width behavior, and variants verified from Figma?
+- Do card internals expand coherently at wider widths?
+- Are long text and narrow viewport cases handled?
+- Are provisional mappings centralized and clearly identified?
+
+### Accessibility and mobile behavior
+
+- Are semantic controls, labels, pressed state, focus-visible, contrast, and live announcements present?
+- Do safe areas, virtual keyboards, dynamic viewport units, and WebView differences affect controls?
+- Does navigation have both native bridge behavior and a safe web fallback where needed?
+
+### Testing and operations
+
+- Are pure transformations, reset behavior, nullable rendering, and submission payloads tested?
+- Are preview/debug routes blocked in production?
+- Do type-check, lint, tests, and build pass?
+- Does local verification accidentally trigger external uploads or mutate production systems?
+
+## 4. Assign severity
+
+- **P0:** security, data loss, production outage, or destructive behavior.
+- **P1:** broken primary flow, incorrect submission/data, public debug exposure, or major accessibility/runtime failure.
+- **P2:** material maintainability, performance, responsive, visual fidelity, edge-case, or test gap likely to cause regressions.
+- **P3:** polish, naming, low-risk cleanup, or optional follow-up.
+
+Every finding must include:
+
+- severity;
+- file and line when available;
+- observed evidence;
+- user or engineering impact;
+- concrete remediation.
+
+Do not inflate severity to make the review look substantial.
+
+## 5. Fix requested severities
+
+When authorized to fix:
+
+1. address P0, then P1, then P2;
+2. add regression tests for behavioral findings;
+3. remove dead abstractions introduced by the change;
+4. keep unresolved Figma/backend values explicitly provisional;
+5. avoid unrelated cleanup.
+
+## 6. Verify and report
+
+Run:
+
+```bash
+yarn type-check
+yarn lint
+yarn test --run
+```
+
+Run `yarn build` when routes, fonts, server/client boundaries, or production guards changed.
+
+Final output order:
+
+1. unresolved findings, highest severity first;
+2. fixes completed;
+3. verification results;
+4. known provisional decisions and existing unrelated warnings.
+
+If no findings remain through the requested threshold, say so explicitly.

--- a/.agents/skills/review-frontend-change/agents/openai.yaml
+++ b/.agents/skills/review-frontend-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "프론트엔드 다관점 리뷰"
+  short_description: "프론트엔드 변경을 다관점 검토하고 P2까지 수정"
+  default_prompt: "Use $review-frontend-change to review the current frontend changes and resolve findings through P2."


### PR DESCRIPTION
## 배경

지금까지 Codex와 작업하면서 저장소 구조 확인, Figma 비교, 다관점 코드 리뷰, PR 작성 방법을 대화로 계속 맞춰 왔습니다.

하지만 이런 방법은 현재 대화가 끝나면 다음 작업에서 다시 설명해야 합니다. `AGENTS.md`에 모든 절차를 넣을 수도 있지만, 그렇게 하면 항상 읽어야 하는 문서가 너무 길어집니다.

그래서 자주 반복하는 작업 방법은 **Codex Skill**로 나눴습니다. Skill은 특정 작업을 요청했을 때만 Codex가 읽는 작업 안내서입니다.

## 해결 과정

### 1. 항상 지킬 규칙과 작업별 절차를 분리했습니다

- `AGENTS.md`: 프로젝트 구조, 명령어, 코딩 규칙처럼 항상 지켜야 하는 내용
- `.agents/skills`: 기능 구현이나 리뷰처럼 특정 작업에서만 필요한 순서와 확인 사항

이렇게 나누면 기본 규칙은 유지하면서도, 매 작업마다 긴 설명을 반복하지 않아도 됩니다.

### 2. 한 Skill이 너무 많은 일을 하지 않도록 역할을 나눴습니다

- `$cchaksa-build-feature`
  - 자연어 요구사항을 실제 기능으로 구현합니다.
  - 웹과 `/mpa/*`, API 준비 상태, 상태 관리, 테스트 범위를 함께 확인합니다.
  - Swagger가 아직 없으면 나중에 교체하기 쉬운 mock 경계를 만듭니다.

- `$figma-implement-ui`
  - Figma의 폰트, 색상, 간격, 반응형 동작을 확인하고 코드에 반영합니다.
  - 값을 추측하지 않고 확인된 값과 임시 값을 구분합니다.
  - 구현 중간부터 스크린샷을 비교해 차이를 줄입니다.

- `$review-frontend-change`
  - 제품 흐름, 코드 구조, React 리렌더링, 접근성, 디자인, API, 테스트 관점으로 변경사항을 검토합니다.
  - 문제를 P0~P3로 나눕니다.
  - “P2까지 수정”처럼 범위를 지정하면 해당 단계까지 수정하고 다시 검증합니다.

- `$create-pr`
  - 현재 diff에서 요청한 파일만 골라 커밋합니다.
  - 필요한 검사를 실행하고 브랜치를 푸시합니다.
  - 변경 파일 목록보다 배경과 해결 과정을 중심으로 쉬운 PR 설명을 작성합니다.
  - 사용자가 요청하지 않으면 PR을 merge하지 않습니다.

### 3. 저장소에서 바로 공유되는 공식 경로를 사용했습니다

Skill은 저장소 루트의 `.agents/skills/<skill-name>/SKILL.md`에 두었습니다.

팀원이 이 PR을 받은 뒤 저장소에서 Codex를 실행하면 자동으로 Skill을 찾습니다. 별도 설치는 필요하지 않습니다. 새 Skill이 바로 보이지 않는 경우 Codex를 다시 시작하면 됩니다.

### 4. 잘못된 Skill 형식을 미리 검사했습니다

Codex의 공식 `quick_validate.py`로 네 Skill의 이름, YAML frontmatter, 필수 필드를 검사했습니다.

## 결과

- 반복해서 설명하던 네 가지 작업 절차를 저장소에서 팀과 공유할 수 있습니다.
- 작업할 때 Skill 이름을 직접 지정할 수도 있고, 요청 내용이 맞으면 Codex가 자동으로 선택할 수도 있습니다.
- 기능 코드나 기존 `AGENTS.md`는 이 PR에 포함하지 않았습니다.

## 어떻게 사용하나요?

Codex에 아래처럼 요청하면 됩니다.

```text
$cchaksa-build-feature 강의평가 API를 실제 서버와 연결해줘

$figma-implement-ui 이 Figma 화면을 현재 컴포넌트에 반영해줘

$review-frontend-change 현재 변경사항을 리뷰하고 P2까지 수정해줘

$create-pr 현재 변경사항만 커밋하고 dev 기준 PR을 만들어줘
```

Skill을 수정한 뒤에는 다음 명령으로 형식을 확인할 수 있습니다.

```bash
python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/<skill-name>
```

## 확인한 내용

- [x] 네 Skill 모두 Codex 공식 validator 통과
- [x] `git diff --check` 통과
- [x] 커밋에 `.agents/skills` 파일만 포함된 것 확인

## 리뷰할 때 봐주세요

- 각 Skill의 역할 구분이 팀의 실제 작업 방식과 맞는지
- 자동으로 선택되는 범위가 너무 넓거나 좁지 않은지
- PR 설명의 난이도가 팀원이 읽기 적절한지

## 아직 하지 않은 것

- 여러 저장소에 설치할 수 있는 Codex Plugin으로 묶지는 않았습니다.
- Skill은 작업 절차를 안내하지만, CI처럼 규칙을 강제로 막지는 않습니다.
- 실제 사용 중 불편한 부분은 `.agents/skills` 파일을 수정하면서 계속 개선할 수 있습니다.
