### PR TITLE
chore: AdMob 검증용 app-ads.txt 추가

### DIFF
--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6527557981566120, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 배경

모바일 앱(척척학사 Android/iOS)에 Google **AdMob** 광고를 붙이는 중입니다. AdMob은 광고 사기(앱 광고 자리 위조)를 막으려고, 앱과 연결된 개발자 웹사이트 도메인의 `app-ads.txt` 파일을 크롤링해서 "이 게시자가 구글에게 광고 판매를 맡겼는지"를 확인합니다.

- 이 파일이 없거나 틀리면 광고가 떠도 **프로그래매틱 광고 수익(실시간 입찰)이 제한**됩니다.
- `app-ads.txt`는 IAB Tech Lab 표준 *Authorized Sellers for Apps* 입니다. 쉽게 말해 웹용 `ads.txt`의 **모바일 앱 버전**입니다.

그래서 `cchaksa.com` 도메인 루트에 `app-ads.txt`를 서빙해야 합니다.

## 해결 과정

- **기존 구조 확인**: 이미 웹 AdSense용 `public/ads.txt`가 같은 방식으로 운영 중이었습니다. Next.js의 `public/` 폴더에 둔 파일은 도메인 루트(`/파일명`)로 그대로 서빙되고, 배포 환경(opennext-cloudflare)이 `.txt`를 `text/plain`으로 응답합니다.
- **가로채기 위험 점검**: 라우터(SPA)가 이 경로를 가로채 `index.html`을 돌려주면 검증이 깨집니다(가장 흔한 실패 원인). 그래서 확인해 보니 — 사용자 미들웨어 없음, `next.config.mjs`에 rewrites/redirects/headers 없음, `robots.txt`도 없음 → **가로챌 것이 없음**을 확인했습니다.
- **선택한 방법**: 새 코드·설정 없이 `public/app-ads.txt` 한 줄짜리 파일만 추가. 이미 검증된 `ads.txt`와 **완전히 같은 경로**라 추가 위험이 없는 게 핵심 이유입니다.
- **내용**: 우리 AdMob 게시자 ID(`pub-6527557981566120`) 한 줄. 웹과 앱이 같은 구글 계정이라 `ads.txt`와 내용이 동일합니다. 커밋된 파일이 `ads.txt`와 **바이트 단위로 같은지**(한 줄 + 개행, CRLF·HTML 섞임 없음)까지 확인했습니다.

## 결과

- `https://cchaksa.com/app-ads.txt` 와 `https://www.cchaksa.com/app-ads.txt` 에서 한 줄 텍스트가 응답되어 AdMob 검증을 통과할 수 있습니다.
- 변경: `public/app-ads.txt` 1개 추가(1줄). 코드 변경 없음.

## 어떻게 사용하나요?

배포 후 아래로 확인합니다.

```bash
curl -i https://www.cchaksa.com/app-ads.txt
curl -i https://cchaksa.com/app-ads.txt
```

둘 다 `200` + `Content-Type: text/plain` + 아래 한 줄이면 정상입니다.

```
google.com, pub-6527557981566120, DIRECT, f08c47fec0942fa0
```

이후 앱 담당자가 AdMob 콘솔에서 재크롤링을 요청하면 보통 **24시간 이내** 반영됩니다.

## 확인한 내용

- [x] 커밋에 `public/app-ads.txt` **1개 파일만** 포함 (관련 없는 변경/untracked 파일 제외)
- [x] 커밋된 내용이 기존 `ads.txt`와 **바이트 단위 동일** (한 줄 + 개행, CRLF·HTML 없음)
- [x] `git diff --check` 통과 (공백 오류 없음)
- [x] 라우터/미들웨어/rewrites/robots **가로채기 없음** 확인
- type-check / lint / build: 코드 변경이 없는 정적 텍스트라 **해당 없음** (ESLint·tsc는 `src/` 대상, 서빙 동작은 운영 중인 `ads.txt`가 같은 경로로 이미 증명)

## 리뷰할 때 봐주세요

- **도메인 인프라(코드 밖)**: `www` ↔ non-www 양쪽에서 `/app-ads.txt`가 같은 내용으로 응답되는지, HTTPS 200인지 — Cloudflare/도메인 설정 영역입니다. (`ads.txt`가 이미 양쪽에서 뜨고 있다면 동일 경로라 자동으로 따라옵니다.)
- **스토어 등록 도메인**: Play Console / App Store Connect에 등록된 웹사이트 도메인이 `cchaksa.com` 계열인지 — AdMob은 그 도메인을 크롤링합니다.

## 아직 하지 않은 것

- www/non-www 리다이렉트·robots 등 **인프라 설정**은 이 PR(코드) 범위 밖 — 웹/인프라 담당 확인이 필요합니다.
- 향후 다른 광고 네트워크/미디에이션을 추가하면 이 파일에 줄을 덧붙이면 됩니다(이번엔 AdMob 한 줄만 필요).
