### PR TITLE
chore: AdMob 검증용 app-ads.txt 추가 (운영 main 반영)

### DIFF
--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6527557981566120, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 배경

모바일 앱(척척학사 Android/iOS)에 Google **AdMob** 광고를 붙이는 중입니다. AdMob은 광고 사기(앱 광고 자리 위조)를 막으려고, 앱과 연결된 개발자 웹사이트 도메인의 `app-ads.txt`를 크롤링해서 "이 게시자가 구글에게 광고 판매를 맡겼는지"를 확인합니다.

- 이 파일이 없거나 틀리면 광고가 떠도 **프로그래매틱 광고 수익(실시간 입찰)이 제한**됩니다.
- `app-ads.txt`는 IAB Tech Lab 표준 *Authorized Sellers for Apps* — 웹용 `ads.txt`의 **모바일 앱 버전**입니다.

**이 PR이 `main`을 대상으로 하는 이유**: AdMob은 실제 **운영 도메인(cchaksa.com)** 의 파일을 크롤링합니다. 즉 이 파일은 프로덕션에 떠 있어야 효력이 생기므로, `dev`에 들어가는 [#243](https://github.com/gyumong/chukchuk-haksa/pull/243)과 **별개로** 운영 반영을 위해 `main`으로도 올립니다. (`main`에는 이미 웹 AdSense용 `ads.txt`만 있고 `app-ads.txt`는 없는 상태)

## 해결 과정

- **기존 구조 확인**: `main`에 이미 `public/ads.txt`가 같은 방식으로 운영 중. Next.js `public/` 파일은 도메인 루트(`/파일명`)로 서빙되고, 배포 환경(opennext-cloudflare)이 `.txt`를 `text/plain`으로 응답합니다.
- **가로채기 위험 점검**: 라우터(SPA)가 이 경로를 가로채 `index.html`을 돌려주면 검증이 깨지는데 — 사용자 미들웨어 없음, `next.config.mjs`에 rewrites/redirects/headers 없음, `robots.txt` 없음 → **가로챌 것 없음** 확인.
- **선택한 방법**: 새 코드·설정 없이 `public/app-ads.txt` 한 줄짜리 파일만 추가. 이미 검증된 `ads.txt`와 **완전히 같은 경로**라 추가 위험이 없습니다.
- **브랜치 구성**: `dev` PR(#243)이 `dev` 위에 쌓인 다른 변경까지 끌고 오지 않도록, 이 PR은 **`main`에서 분기해 해당 커밋만 cherry-pick** 했습니다. 그래서 `main` 대비 **정확히 `app-ads.txt` 1개 파일**만 변경됩니다.

## 결과

- `https://cchaksa.com/app-ads.txt`, `https://www.cchaksa.com/app-ads.txt` 에서 한 줄 텍스트가 응답되어 AdMob 검증을 통과할 수 있습니다.
- 변경: `public/app-ads.txt` 1개 추가(1줄). 코드 변경 없음. `#243`(→dev)과 **동일 내용**입니다.

## 어떻게 사용하나요?

배포 후 확인:

```bash
curl -i https://www.cchaksa.com/app-ads.txt
curl -i https://cchaksa.com/app-ads.txt
```

둘 다 `200` + `Content-Type: text/plain` + 아래 한 줄이면 정상:

```
google.com, pub-6527557981566120, DIRECT, f08c47fec0942fa0
```

이후 앱 담당자가 AdMob 콘솔에서 재크롤링을 요청하면 보통 **24시간 이내** 반영됩니다.

## 확인한 내용

- [x] `main`에서 분기 후 해당 커밋만 cherry-pick → `main` 대비 **`public/app-ads.txt` 1개 파일만** 변경
- [x] 커밋 내용이 `#243`(dev) 및 기존 `ads.txt`와 **바이트 단위 동일**
- [x] `git diff --check` 통과 (공백 오류 없음)
- [x] 라우터/미들웨어/rewrites/robots **가로채기 없음** 확인
- type-check / lint / build: 코드 변경 없는 정적 텍스트라 **해당 없음** (서빙은 운영 중인 `ads.txt`가 같은 경로로 이미 증명)

## 리뷰할 때 봐주세요

- **`dev` PR(#243)과의 중복 머지**: 두 PR이 같은 파일을 추가하므로, 둘 다 머지돼도 내용이 동일해 `dev`→`main` 머지 시 충돌이 없습니다. 운영 급한 정도에 따라 이 PR을 먼저 머지할지 결정해 주세요.
- **도메인 인프라(코드 밖)**: `www` ↔ non-www 양쪽 서빙, HTTPS 200 — Cloudflare/도메인 설정 영역 (`ads.txt`가 이미 양쪽에서 뜨고 있다면 동일 경로라 자동으로 따라옵니다).

## 아직 하지 않은 것

- www/non-www 리다이렉트·robots 등 **인프라 설정**은 이 PR 범위 밖 — 웹/인프라 담당 확인 필요.
- 향후 다른 광고 네트워크 추가 시 이 파일에 줄을 덧붙이면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타**
  * Google 광고 퍼블리셔 인증 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->