### PR TITLE
feat: 텍소노미 이벤트 3종 추가 + 웹 버전 1.14.0 + iOS 로딩 영상 자동재생 보강

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chukchuk-haksa",
-  "version": "0.1.0",
+  "version": "1.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(funnel)/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/app/(funnel)/components/LoadingScreen/LoadingScreen.tsx
@@ -59,6 +59,11 @@ const LoadingScreen = () => {
     if (!video) {
       return;
     }
+    // React 는 SSR/hydration 시 <video> 의 muted 를 DOM 에 반영하지 않는 경우가 있어 hydration 후
+    // video.muted 가 false 로 남는다. iOS(WKWebView)는 unmuted 동영상의 제스처 없는 자동재생을 막으므로
+    // play() 가 NotAllowedError 로 거부된다. play() 직전에 muted 를 프로퍼티+속성 양쪽으로 강제한다.
+    video.muted = true;
+    video.setAttribute('muted', '');
     void video.play().catch(captureException);
   }, []);
 
@@ -83,9 +88,7 @@ const LoadingScreen = () => {
         </div>
       </main>
 
-      <div className={styles.bottomBar}>
-        {!isWebView && <div className={styles.indicator} />}
-      </div>
+      <div className={styles.bottomBar}>{!isWebView && <div className={styles.indicator} />}</div>
     </div>
   );
 };

--- a/src/app/(funnel)/scraping/page.tsx
+++ b/src/app/(funnel)/scraping/page.tsx
@@ -4,14 +4,14 @@ import { useEffect, useRef } from 'react';
 import { setUser } from '@sentry/nextjs';
 import { FixedButton } from '@/components/ui';
 import { ROUTES } from '@/constants/routes';
-import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
 import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
-import { EVENTS, useTrackView } from '@/lib/analytics';
-import { useFunnelContext } from '../contexts';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
 import ErrorScreen from '../components/ErrorScreen/ErrorScreen';
 import LoadingScreen from '../components/LoadingScreen/LoadingScreen';
+import { useFunnelContext } from '../contexts';
 import styles from './error.module.scss';
 
 const MISSING_JOB_MESSAGE = '연동 정보를 찾을 수 없습니다. 다시 시도해주세요.';
@@ -39,6 +39,7 @@ export default function ScrapingPage() {
     // 성공 판정(studentInfo)과 동일 신호로 맞춰, 성공이 확정되면 타임아웃 실패가 절대 안 뜨게 한다.
     recovered: Boolean(summaryData?.studentInfo),
     loginRoute: ROUTES.FUNNEL.PORTAL_LOGIN,
+    onFailure: reason => track(EVENTS.UNIV_SYNC_FAIL, { reason }),
   });
 
   useEffect(() => {

--- a/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
+++ b/src/app/(mpa)/mpa/portal-login/scraping/page.tsx
@@ -2,17 +2,17 @@
 
 // /mpa/resync/scraping 과 동일 흐름. portal-login entry point 의 후행 페이지. 프로토콜: docs/mpa-school-link-handoff.md
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FixedButton } from '@/components/ui';
-import { ROUTES } from '@/constants/routes';
-import { useInternalRouter } from '@/hooks/useInternalRouter';
-import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
-import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
-import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
-import { EVENTS, useTrackView } from '@/lib/analytics';
-import { isInWebView, postBridgeMessage } from '@/lib/webview';
 import ErrorScreen from '@/app/(funnel)/components/ErrorScreen/ErrorScreen';
 import LoadingScreen from '@/app/(funnel)/components/LoadingScreen/LoadingScreen';
 import errorStyles from '@/app/resync/scraping/error.module.scss';
+import { FixedButton } from '@/components/ui';
+import { PORTAL_LOGIN_JOB_ID_KEY } from '@/constants/portal-link';
+import { ROUTES } from '@/constants/routes';
+import { usePortalLinkFailure, usePortalLinkJobPolling, usePortalLinkSummary } from '@/features/portal-link/hooks';
+import { clearRetry } from '@/features/portal-link/utils/credentialRetry';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
+import { isInWebView, postBridgeMessage } from '@/lib/webview';
 
 // 잡 완료 시 네이티브로 보내는 신호. webview 환경 아니면 fallback 으로 main 이동.
 // 프로토콜 합의는 docs/mpa-school-link-handoff.md 참조.
@@ -80,6 +80,7 @@ export default function MpaPortalLoginScrapingPage() {
     recovered: isSucceeded,
     loginRoute: ROUTES.MPA.PORTAL_LOGIN,
     onCleanup: clearJobId,
+    onFailure: reason => track(EVENTS.UNIV_SYNC_FAIL, { reason }),
   });
 
   const handleRetry = () => {

--- a/src/app/(mpa)/mpa/resync/login/page.tsx
+++ b/src/app/(mpa)/mpa/resync/login/page.tsx
@@ -3,20 +3,21 @@
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { captureException } from '@sentry/nextjs';
+import { FunnelHeadline, SchoolCard } from '@/app/(funnel)/components';
+import styles from '@/app/resync/login/page.module.scss';
 import { FixedButton, TextField } from '@/components/ui';
+import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
 import { ROUTES } from '@/constants/routes';
-import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
 import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
-import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
-import { EVENTS, track } from '@/lib/analytics';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
-import { FunnelHeadline, SchoolCard } from '@/app/(funnel)/components';
-import styles from '@/app/resync/login/page.module.scss';
 
 export default function MpaResyncLogin() {
+  useTrackView(EVENTS.UNIV_RESYNC_LOGIN_VIEW);
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');

--- a/src/app/resync/login/page.tsx
+++ b/src/app/resync/login/page.tsx
@@ -4,19 +4,20 @@ import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { captureException } from '@sentry/nextjs';
 import { FixedButton, TextField } from '@/components/ui';
+import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
 import { ROUTES } from '@/constants/routes';
-import { useInternalRouter } from '@/hooks/useInternalRouter';
 import { usePortalLinkMutation } from '@/features/portal-link/hooks';
 import { popRetry, stashAttemptUsername } from '@/features/portal-link/utils/credentialRetry';
 import { getMessageByErrorCode } from '@/features/portal-link/utils/errorMapping';
-import { RESYNC_JOB_ID_KEY } from '@/constants/portal-link';
-import { EVENTS, track } from '@/lib/analytics';
+import { useInternalRouter } from '@/hooks/useInternalRouter';
+import { EVENTS, track, useTrackView } from '@/lib/analytics';
 import { ApiError } from '@/shared/api/errors';
 import { generateIdempotencyKey } from '@/shared/utils/idempotency';
 import { FunnelHeadline, SchoolCard } from '../../(funnel)/components';
 import styles from './page.module.scss';
 
 export default function PortalLogin() {
+  useTrackView(EVENTS.UNIV_RESYNC_LOGIN_VIEW);
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -96,7 +97,11 @@ export default function PortalLogin() {
           </div>
         )}
 
-        <FixedButton type="submit" disabled={!username || !password || linkMutation.isPending} isLoading={linkMutation.isPending}>
+        <FixedButton
+          type="submit"
+          disabled={!username || !password || linkMutation.isPending}
+          isLoading={linkMutation.isPending}
+        >
           학업 이력 동기화하기
         </FixedButton>
       </form>

--- a/src/features/ads/useRewardedAdGate.tsx
+++ b/src/features/ads/useRewardedAdGate.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import { captureException } from '@sentry/nextjs';
+import { EVENTS, track } from '@/lib/analytics';
 import { AD_UNITS } from './adUnits';
 
 // 광고 시청 결과.
@@ -159,6 +160,8 @@ export function useRewardedAdGate() {
               settle('unavailable');
             }
           };
+          // 광고 안내 팝업(opt-in 다이얼로그) 실제 노출 시점.
+          track(EVENTS.AD_CONFIRM_POPUP);
           setIsOpen(true);
         };
         const onGranted = (event: RewardedEvent) => {

--- a/src/features/portal-link/hooks/usePortalLinkFailure.ts
+++ b/src/features/portal-link/hooks/usePortalLinkFailure.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { captureException } from '@sentry/nextjs';
-import { useInternalRouter, type RoutePath } from '@/hooks/useInternalRouter';
+import { type RoutePath, useInternalRouter } from '@/hooks/useInternalRouter';
 import type { JobStatusResponse } from '@/shared/api/data-contracts';
 import { stashRetryCode } from '../utils/credentialRetry';
 import { classifyPortalLinkFailure, TIMEOUT_ERROR_MESSAGE } from '../utils/errorMapping';
@@ -20,6 +20,11 @@ interface UsePortalLinkFailureParams {
   loginRoute: RoutePath;
   /** 실패 처리 직전 정리 (예: sessionStorage jobId 제거). */
   onCleanup?: () => void;
+  /**
+   * 실패 확정 시 1회 호출. reason = 포털 에러 코드(예: 'T01','S04','PORTAL_AUTH_FAILED') 또는 'TIMEOUT'.
+   * 첫 로그인 흐름에서 텍소노미 univ_sync_fail 발사에 사용 (재연동 호출부는 전달하지 않음).
+   */
+  onFailure?: (reason: string) => void;
 }
 
 /**
@@ -38,6 +43,7 @@ export function usePortalLinkFailure({
   recovered = false,
   loginRoute,
   onCleanup,
+  onFailure,
 }: UsePortalLinkFailureParams) {
   const router = useInternalRouter();
   const [failureMessage, setFailureMessage] = useState<string | null>(null);
@@ -50,6 +56,8 @@ export function usePortalLinkFailure({
     if (jobStatus === 'failed' && jobDetail) {
       handledRef.current = true;
       const { kind, code, message, shouldCapture } = classifyPortalLinkFailure(jobDetail);
+      // 모든 실패 종류(credential/ineligible/system)를 포괄 — credential 의 early-return 전에 발사.
+      onFailure?.(code || 'UNKNOWN');
       onCleanup?.();
 
       if (kind === 'credential') {
@@ -63,7 +71,7 @@ export function usePortalLinkFailure({
       }
       setFailureMessage(message);
     }
-  }, [jobStatus, jobDetail, loginRoute, onCleanup, router]);
+  }, [jobStatus, jobDetail, loginRoute, onCleanup, onFailure, router]);
 
   useEffect(() => {
     if (handledRef.current) {
@@ -73,11 +81,12 @@ export function usePortalLinkFailure({
     // summary 가 성공을 확인하면(recovered) 성공 핸들러가 처리하므로 여기선 실패 처리하지 않는다.
     if (isTimedOut && summaryResolved && !recovered) {
       handledRef.current = true;
+      onFailure?.('TIMEOUT');
       onCleanup?.();
       captureException(new Error('[portal-link] timeout'));
       setFailureMessage(TIMEOUT_ERROR_MESSAGE);
     }
-  }, [isTimedOut, summaryResolved, recovered, onCleanup]);
+  }, [isTimedOut, summaryResolved, recovered, onCleanup, onFailure]);
 
   return { failureMessage };
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -7,6 +7,7 @@ export const EVENTS = {
   UNIV_SYNC_LOGIN_VIEW: 'univ_sync_login_view',
   UNIV_SYNC_BTN_TAP: 'univ_sync_btn_tap',
   UNIV_SYNC_LOADING_VIEW: 'univ_sync_loading_view',
+  UNIV_SYNC_FAIL: 'univ_sync_fail',
   UNIV_SYNC_TERM_AGREE_BOTTOMSHEET_VIEW: 'univ_sync_term_agree_bottomsheet_view',
   UNIV_SYNC_TERM_AGREE_VIEW: 'univ_sync_term_agree_view',
   UNIV_SYNC_COMPLETE_VIEW: 'univ_sync_complete_view',
@@ -17,6 +18,8 @@ export const EVENTS = {
 
   // 학교 재연동 (홈에서 갱신 흐름)
   HOME_UNIV_RESYNC_BTN_TAP: 'home_univ_resync_btn_tap',
+  AD_CONFIRM_POPUP: 'ad_confirm_popup',
+  UNIV_RESYNC_LOGIN_VIEW: 'univ_resync_login_view',
   UNIV_RESYNC_BTN_TAP: 'univ_resync_btn_tap',
   UNIV_RESYNC_LOADING_VIEW: 'univ_resync_loading_view',
   UNIV_RESYNC_COMPLETE: 'univ_resync_complete',
@@ -28,15 +31,21 @@ export interface SetGpaTapProps {
   gpa: number;
 }
 
+export interface SyncFailProps {
+  // 포털 연동 실패 코드 (예: 'T01', 'S04', 'PORTAL_AUTH_FAILED') 또는 'TIMEOUT' / 'UNKNOWN'.
+  reason: string;
+}
+
 export type EventName = (typeof EVENTS)[keyof typeof EVENTS];
 
 // 페이로드 없는 이벤트 — name 만 받음.
-type EventNameWithoutProps = Exclude<EventName, typeof EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP>;
+type EventNameWithoutProps = Exclude<EventName, typeof EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP | typeof EVENTS.UNIV_SYNC_FAIL>;
 
 // 타입 안전 wrapper — amplitude.track 직접 호출 차단. overload 로 페이로드 강제.
 export function track(name: typeof EVENTS.UNIV_SYNC_SET_GPA_BTN_TAP, properties: SetGpaTapProps): void;
+export function track(name: typeof EVENTS.UNIV_SYNC_FAIL, properties: SyncFailProps): void;
 export function track(name: EventNameWithoutProps): void;
-export function track(name: EventName, properties?: SetGpaTapProps): void {
+export function track(name: EventName, properties?: SetGpaTapProps | SyncFailProps): void {
   trackEvent(name, properties as Record<string, unknown> | undefined);
 }
 


### PR DESCRIPTION
## 배경

- 분석(Amplitude) 텍소노미에 새 이벤트 3종이 추가됐는데 코드에는 아직 안 박혀 있었습니다.
  - `univ_sync_fail` — 첫 로그인 학교 연동 실패
  - `ad_confirm_popup` — 갱신하기 보상형 광고 안내 팝업 노출
  - `univ_resync_login_view` — 재연동 로그인(학번/비번) 뷰 노출
- 네이티브에 넘기는 웹 버전(`sys_web_version`)이 `0.1.0`에 멈춰 있어 이번 릴리즈(1.14.0)와 맞지 않았습니다.
- iOS 폰에서 연동/재연동 **로딩 화면의 안내 영상이 재생되지 않는** 문제가 있었습니다.

## 해결 과정

- **텍소노미 이벤트**: `src/lib/analytics/events.ts` 의 `EVENTS` 에 3종을 추가하고 각 시점에 wiring했습니다.
  - `univ_sync_fail` 은 **첫 로그인 연동에서만** 발사해야 해서(재연동과 구분), 4개 흐름이 공유하는 훅 `usePortalLinkFailure` 에 `onFailure(reason)` 콜백을 추가하고 **첫 로그인 scraping 2종에서만** 전달했습니다. `reason` 에는 포털 에러 코드(T01/S04 등) 또는 `TIMEOUT` 이 들어갑니다.
  - `ad_confirm_popup` 은 보상형 광고 opt-in 다이얼로그가 실제로 뜨는 시점(`useRewardedAdGate` 의 onReady)에 발사합니다.
  - `univ_resync_login_view` 는 재연동 로그인 페이지(웹/웹뷰 양쪽) mount 시 `useTrackView` 로 발사합니다.
- **웹 버전**: `package.json` 의 version 만 1.14.0 으로 올렸습니다. `AnalyticsProvider` 가 이 값을 `sys_web_version` User Property 로 자동 전달하므로 다른 수정은 필요 없습니다.
- **iOS 영상**: 조사 결과 웹 `<video>` 는 이미 `muted/playsInline/autoPlay` 를 모두 갖췄고, 진짜 원인은 네이티브 WKWebView 설정입니다. 다만 React 가 SSR/hydration 시 `muted` 를 DOM 에 반영하지 않는 알려진 동작이 겹쳐, `play()` 직전에 `video.muted = true` 를 명시적으로 강제하도록 보강했습니다. (iOS 는 음소거되지 않은 영상의 자동재생을 막습니다.)

## 결과

- 새 이벤트 3종이 적절한 시점에 전송됩니다(웹 + 웹뷰).
- 네이티브로 넘기는 `sys_web_version` 이 1.14.0 으로 나갑니다.
- iOS 자동재생을 막던 웹쪽 muted 누락 가능성을 제거했습니다(네이티브 설정과 함께 동작).

## 확인한 내용

- [x] `yarn type-check` 통과
- [x] `yarn lint` 통과 (기존 경고 18건 외 신규 0건, error 0)

## 리뷰할 때 봐주세요

- `univ_sync_fail` 을 모든 실패 종류(credential/ineligible/system/timeout)에 발사하도록 했습니다. 즉 비밀번호 오류(credential)도 "연동 실패"로 집계됩니다 — 이 집계 기준이 맞는지 확인 부탁드립니다.
- iOS 영상은 **네이티브 WKWebView 설정**(`allowsInlineMediaPlayback = true`, `mediaTypesRequiringUserActionForPlayback = []`)이 함께 적용돼야 최종 해결됩니다. 이 PR 은 웹쪽 보강만 담고 있습니다.

## 아직 하지 않은 것

- **MPA(웹뷰) 텍소노미 미전송 이슈**: 분석 코드에 webview 가드는 없습니다. 실제 원인(빌드 시 Amplitude 키 누락 / 웹뷰 스토리지·전송 / 인증 게이트 타이밍)은 실기기 확인이 필요해 별도로 추적합니다.
- 강의평가 `evaluationStatus: null` 응답은 백엔드가 `NOT_RELEASED` 로 주는 것이 맞습니다(백엔드 과제). 이 PR 범위 밖입니다.
