### PR TITLE
fix: PR #250 CodeRabbit 리뷰 반영 (강의평가·광고·e2e)

### DIFF
--- a/e2e/fixtures/admin.ts
+++ b/e2e/fixtures/admin.ts
@@ -43,6 +43,19 @@ interface AdminCallOptions {
   data?: unknown;
 }
 
+// Spring 래퍼({ success, data, message, error })에서 success:false 면 message/error 를 붙여 즉시 throw.
+// adminFetch 와 fetchIsPortalLinked 가 동일 계약을 공유하므로 검사 로직을 한 곳에 둔다.
+function assertWrapperSuccess(
+  context: string,
+  wrapper: { success?: boolean; message?: string; error?: unknown }
+): void {
+  if (wrapper.success === false) {
+    throw new Error(
+      `[admin] ${context} → success:false ${wrapper.message ?? ''} ${JSON.stringify(wrapper.error ?? null)}`.trim()
+    );
+  }
+}
+
 // 래퍼 언랩 + 실패/비JSON 응답은 상태코드·본문을 그대로 노출해 디버깅이 쉽도록 한다.
 async function adminFetch<T>(method: Method, path: string, options: AdminCallOptions = {}): Promise<T> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -55,7 +68,15 @@ async function adminFetch<T>(method: Method, path: string, options: AdminCallOpt
     init.body = JSON.stringify(options.data ?? {});
   }
 
-  const res = await fetch(`${ADMIN_BASE}${path}`, init);
+  let res: Response;
+  try {
+    res = await fetch(`${ADMIN_BASE}${path}`, init);
+  } catch (err) {
+    if (err instanceof Error && err.name === 'TimeoutError') {
+      throw new Error(`[admin] ${method} ${path} → ${ADMIN_REQUEST_TIMEOUT_MS}ms 타임아웃`);
+    }
+    throw err;
+  }
   const text = await res.text();
   if (!res.ok) {
     throw new Error(`[admin] ${method} ${path} → ${res.status} ${text.slice(0, 300)}`);
@@ -72,11 +93,7 @@ async function adminFetch<T>(method: Method, path: string, options: AdminCallOpt
   // 200 + success:false 를 정상값처럼 흘려보내면 후속 테스트가 오염되므로 즉시 throw.
   if (body && typeof body === 'object' && 'success' in body) {
     const wrapper = body as { success?: boolean; data?: T; message?: string; error?: unknown };
-    if (wrapper.success === false) {
-      throw new Error(
-        `[admin] ${method} ${path} → success:false ${wrapper.message ?? ''} ${JSON.stringify(wrapper.error ?? null)}`.trim()
-      );
-    }
+    assertWrapperSuccess(`${method} ${path}`, wrapper);
     return wrapper.data as T;
   }
   // 래퍼가 아니어도 data 키만 있으면 언랩(구버전 호환), 아니면 그대로 반환.
@@ -172,8 +189,6 @@ export async function fetchIsPortalLinked(token: string): Promise<boolean> {
     throw new Error(`[admin] GET /api/users/me 응답이 JSON 이 아님: ${text.slice(0, 200)}`);
   }
   // 200 + success:false 를 false 로 축소하지 않고 명확히 실패시킨다.
-  if (body?.success === false) {
-    throw new Error(`[admin] GET /api/users/me → success:false ${body.message ?? ''}`.trim());
-  }
+  assertWrapperSuccess('GET /api/users/me', body);
   return Boolean(body?.data?.isPortalLinked ?? body?.isPortalLinked);
 }

--- a/e2e/fixtures/admin.ts
+++ b/e2e/fixtures/admin.ts
@@ -10,6 +10,10 @@
 // /me/** 는 테스트 계정의 raw accessToken 을 Bearer 로 사용한다.
 import { ADMIN_BASE } from './config';
 
+// dev 백엔드가 연결만 잡고 응답을 멈추는 경우, 바깥쪽 Playwright timeout 까지 가지 않고
+// fixture 단계에서 빠르게 실패하도록 공통 request timeout 을 건다.
+const ADMIN_REQUEST_TIMEOUT_MS = 15000;
+
 export type Role = 'linked' | 'unlinked';
 
 export interface TestUser {
@@ -46,7 +50,7 @@ async function adminFetch<T>(method: Method, path: string, options: AdminCallOpt
     headers.Authorization = `Bearer ${options.token}`;
   }
 
-  const init: RequestInit = { method, headers };
+  const init: RequestInit = { method, headers, signal: AbortSignal.timeout(ADMIN_REQUEST_TIMEOUT_MS) };
   if (method !== 'GET') {
     init.body = JSON.stringify(options.data ?? {});
   }
@@ -64,7 +68,18 @@ async function adminFetch<T>(method: Method, path: string, options: AdminCallOpt
     throw new Error(`[admin] ${method} ${path} 응답이 JSON 이 아님: ${text.slice(0, 200)}`);
   }
 
-  // Spring 래퍼면 data 를, 아니면 그대로 반환.
+  // Spring 래퍼({ success, data, message, error })면 success 를 먼저 검사한다.
+  // 200 + success:false 를 정상값처럼 흘려보내면 후속 테스트가 오염되므로 즉시 throw.
+  if (body && typeof body === 'object' && 'success' in body) {
+    const wrapper = body as { success?: boolean; data?: T; message?: string; error?: unknown };
+    if (wrapper.success === false) {
+      throw new Error(
+        `[admin] ${method} ${path} → success:false ${wrapper.message ?? ''} ${JSON.stringify(wrapper.error ?? null)}`.trim()
+      );
+    }
+    return wrapper.data as T;
+  }
+  // 래퍼가 아니어도 data 키만 있으면 언랩(구버전 호환), 아니면 그대로 반환.
   if (body && typeof body === 'object' && 'data' in body) {
     return (body as { data: T }).data;
   }
@@ -144,16 +159,21 @@ export function addTestCourse(token: string, course: TestCourseInput): Promise<T
 export async function fetchIsPortalLinked(token: string): Promise<boolean> {
   const res = await fetch(`${ADMIN_BASE}/api/users/me`, {
     headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(ADMIN_REQUEST_TIMEOUT_MS),
   });
   const text = await res.text();
   if (!res.ok) {
     throw new Error(`[admin] GET /api/users/me → ${res.status} ${text.slice(0, 200)}`);
   }
-  let body: { data?: { isPortalLinked?: boolean }; isPortalLinked?: boolean };
+  let body: { success?: boolean; data?: { isPortalLinked?: boolean }; isPortalLinked?: boolean; message?: string };
   try {
     body = JSON.parse(text);
   } catch {
     throw new Error(`[admin] GET /api/users/me 응답이 JSON 이 아님: ${text.slice(0, 200)}`);
+  }
+  // 200 + success:false 를 false 로 축소하지 않고 명확히 실패시킨다.
+  if (body?.success === false) {
+    throw new Error(`[admin] GET /api/users/me → success:false ${body.message ?? ''}`.trim());
   }
   return Boolean(body?.data?.isPortalLinked ?? body?.isPortalLinked);
 }

--- a/src/features/academic/components/detail/GradeCard.module.scss
+++ b/src/features/academic/components/detail/GradeCard.module.scss
@@ -47,7 +47,6 @@
   color: color.$black-100;
   @include typography.body-lg;
   @include typography.font-weight-bold;
-  word-wrap: break-word;
   overflow-wrap: break-word;
   // flex 자식이라 줄바꿈하려면 min-width:0 필요.
   min-width: 0;

--- a/src/features/ads/useRewardedAdGate.tsx
+++ b/src/features/ads/useRewardedAdGate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { captureException } from '@sentry/nextjs';
 import { EVENTS, track } from '@/lib/analytics';
 import { AD_UNITS } from './adUnits';
@@ -188,6 +188,15 @@ export function useRewardedAdGate() {
         googletag.display(definedSlot);
       });
     });
+  }, []);
+
+  // 진행 중인 광고 플로우가 settle 되기 전에 컴포넌트가 unmount 되면 타이머/pubads 리스너/슬롯이 누수된다.
+  // settleRef 는 현재 플로우의 정리 경로(clearTimeout + removeEventListener + destroySlots)를 가리키므로,
+  // 언마운트 시 dismissed 로 정리해 orphan 상태가 남지 않게 한다.
+  useEffect(() => {
+    return () => {
+      settleRef.current?.('dismissed');
+    };
   }, []);
 
   // 동의: 광고 노출. 결과(granted/dismissed)는 GPT 이벤트로 settle.

--- a/src/features/lecture-evaluation/components/LectureEvaluationIntro/LectureEvaluationIntro.tsx
+++ b/src/features/lecture-evaluation/components/LectureEvaluationIntro/LectureEvaluationIntro.tsx
@@ -42,7 +42,7 @@ export function LectureEvaluationIntro({ grade, onOpen, onSkip, isSkipping = fal
   }, [isHighGrade, isOpening, onOpen]);
 
   const handleOpen = () => {
-    if (!isOpening) {
+    if (!isOpening && !isSkipping) {
       setIsOpening(true);
     }
   };
@@ -53,7 +53,7 @@ export function LectureEvaluationIntro({ grade, onOpen, onSkip, isSkipping = fal
         type="button"
         className={`${styles.introCard} ${isHighGrade ? styles.highGrade : ''} ${isOpening ? styles.opening : ''}`}
         aria-label={`${grade.courseName} 성적 카드 열기`}
-        disabled={isOpening}
+        disabled={isOpening || isSkipping}
         onClick={handleOpen}
       >
         <span className={styles.introHeader}>
@@ -110,7 +110,7 @@ export function LectureEvaluationIntro({ grade, onOpen, onSkip, isSkipping = fal
       </button>
 
       <div className={styles.skipArea}>
-        <button type="button" className={styles.skipButton} disabled={isSkipping} onClick={onSkip}>
+        <button type="button" className={styles.skipButton} disabled={isSkipping || isOpening} onClick={onSkip}>
           강의평가 건너뛰기
         </button>
         <p>*수강랭킹은 강의평가 참여 유저만 제공됩니다.</p>

--- a/src/features/lecture-evaluation/components/LectureEvaluationScreen/LectureEvaluationScreen.tsx
+++ b/src/features/lecture-evaluation/components/LectureEvaluationScreen/LectureEvaluationScreen.tsx
@@ -25,14 +25,17 @@ export function LectureEvaluationScreen({ exitRoute }: LectureEvaluationScreenPr
   const [isIntroOpen, setIsIntroOpen] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
   const isPending = data.evaluationStatus === 'PENDING';
+  // PENDING 이어도 평가할 성적이 없으면 머무를 화면이 없으므로 종료 경로로 보낸다.
+  // (이 케이스를 redirect 조건에서 빼면 영구 공백 화면에 갇힌다.)
+  const shouldExit = !isPending || data.grades.length === 0;
 
   useEffect(() => {
-    if (!isPending) {
+    if (shouldExit) {
       router.replace(exitRoute);
     }
-  }, [exitRoute, isPending, router]);
+  }, [exitRoute, shouldExit, router]);
 
-  if (!isPending || data.grades.length === 0) {
+  if (shouldExit) {
     return null;
   }
 

--- a/src/features/lecture-evaluation/utils/__tests__/grade.test.ts
+++ b/src/features/lecture-evaluation/utils/__tests__/grade.test.ts
@@ -11,6 +11,10 @@ describe('getGradeBand', () => {
     ['P', 'p'],
     ['F', 'fallback'],
     ['S', 'fallback'],
+    // 정규화(trim + toUpperCase) 와 fallback 계약 회귀 방지.
+    [' a+ ', 'a'],
+    ['p', 'p'],
+    ['', 'fallback'],
   ])('%s 성적을 %s 색상 그룹으로 분류한다', (grade, expected) => {
     expect(getGradeBand(grade)).toBe(expected);
   });

--- a/src/features/lecture-evaluation/utils/draftStore.ts
+++ b/src/features/lecture-evaluation/utils/draftStore.ts
@@ -4,8 +4,10 @@ import { createEvaluationDrafts, toggleEvaluationTag, updateEvaluationReview } f
 type Listener = () => void;
 
 export interface LectureEvaluationDraftStore {
-  getDrafts: () => LectureEvaluationDraft[];
-  getSelectedTags: (index: number) => LectureEvaluationTag[];
+  // 내부 배열을 직접 노출하면 호출 측 mutation 이 toggleTag/updateReview 를 우회해 notify 가 안 돌 수 있다.
+  // 외부에는 readonly 로만 노출해 구독 모델(useSyncExternalStore)과 제출 데이터의 정합성을 지킨다.
+  getDrafts: () => readonly LectureEvaluationDraft[];
+  getSelectedTags: (index: number) => readonly LectureEvaluationTag[];
   getReview: (index: number) => string;
   toggleTag: (index: number, tag: LectureEvaluationTag) => void;
   updateReview: (index: number, review: string) => void;

--- a/src/features/lecture-evaluation/utils/draftStore.ts
+++ b/src/features/lecture-evaluation/utils/draftStore.ts
@@ -6,7 +6,7 @@ type Listener = () => void;
 export interface LectureEvaluationDraftStore {
   // 내부 배열을 직접 노출하면 호출 측 mutation 이 toggleTag/updateReview 를 우회해 notify 가 안 돌 수 있다.
   // 외부에는 readonly 로만 노출해 구독 모델(useSyncExternalStore)과 제출 데이터의 정합성을 지킨다.
-  getDrafts: () => readonly LectureEvaluationDraft[];
+  getDrafts: () => ReadonlyArray<Readonly<LectureEvaluationDraft>>;
   getSelectedTags: (index: number) => readonly LectureEvaluationTag[];
   getReview: (index: number) => string;
   toggleTag: (index: number, tag: LectureEvaluationTag) => void;

--- a/src/features/lecture-evaluation/utils/evaluationDraft.ts
+++ b/src/features/lecture-evaluation/utils/evaluationDraft.ts
@@ -35,13 +35,14 @@ export function updateEvaluationReview(draft: LectureEvaluationDraft, review: st
 export function buildSubmitLectureEvaluationsRequest(
   year: number,
   semester: number,
-  drafts: LectureEvaluationDraft[]
+  drafts: readonly LectureEvaluationDraft[]
 ): SubmitLectureEvaluationsRequest {
   return {
     year,
     semester,
     evaluations: drafts.map(draft => {
-      const review = draft.review.trim();
+      // updateEvaluationReview 를 거치지 않은 draft 도 안전하도록 제출 직전 한 번 더 2000자로 제한한다.
+      const review = draft.review.trim().slice(0, 2000);
 
       return {
         courseId: draft.courseId,


### PR DESCRIPTION
## 무엇을 / 왜

병합된 dev→main 릴리스 PR **#250** 의 CodeRabbit 인라인 리뷰 **39건**을 현재 `dev` 코드와 대조해, 게이트(ESLint/tsc/e2e)와 저장소 관례 기준으로 **유효한 8건**을 반영한 후속 PR입니다.
(#250 은 이미 병합됐고 head 가 보호 브랜치 `dev` 라, 직접 푸시 대신 이 후속 브랜치로 분리했습니다.)

## 반영 (8)

- **e2e/fixtures/admin.ts** — Spring 래퍼 `success=false` 시 throw + 요청 타임아웃(`AbortSignal`)
- **LectureEvaluationScreen** — `PENDING` 인데 성적 0건일 때 영구 공백 화면 대신 `exitRoute` 리다이렉트
- **LectureEvaluationIntro** — 카드 열기/건너뛰기 버튼 상호 비활성화(두 흐름 중첩 방지)
- **evaluationDraft** — 제출 직전 후기 2000자 재제한(UI 우회 draft 방어)
- **draftStore** — 외부 노출 배열 `readonly` 타입화(`useSyncExternalStore` 정합성)
- **useRewardedAdGate** — 언마운트 시 타이머/리스너/슬롯 정리(누수 방지)
- **GradeCard.module.scss** — 중복 deprecated `word-wrap` 제거
- **grade.test** — 정규화/빈 입력 회귀 케이스 추가

## 대표 미반영 사유 (총 31건)

- **path-alias 5건** — 피처가 상대경로 일관 사용(58:0). 일부만 바꾸면 일관성 붕괴
- **stylelint/markdownlint 다수** — 저장소 CI에 해당 린터 없음(ESLint/tsc만) → 게이트 무관 포맷팅
- **config.ts 필수 env** — e2e 계획 #3 의 의도된 dev 폴백 결정
- **terms/page** — `/terms=개인정보처리방침`은 의도된 라우트(이력 `a39bdcf`), 별도 약관 콘텐츠 부재 → 제품 판단 필요
- **typography mixin·반응형·EntryGate Suspense** — shipped 코드 대상 heavy 리팩터(범위 밖)

> 39건 전체 판정표는 커밋 메시지 본문 참고.

## 검증

- `yarn type-check`: 0 에러
- `yarn lint`: 0 에러 (기존 warning 18건은 무관)
- `yarn vitest`(grade, draftStore): 15 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 강의평가 화면에서 건너뛰기와 열기 동작이 서로 충돌하지 않도록 상태 처리를 개선했습니다.
  * 평가 대상이 없거나 처리 완료된 경우 더 일관되게 이전 화면으로 이동합니다.
  * 제출 시 입력 내용이 자동으로 정리되고, 너무 긴 후기가 안전하게 잘리도록 개선했습니다.
  * 광고 흐름이 중간에 종료돼도 깔끔하게 정리되도록 수정했습니다.

* **Style**
  * 과목명처럼 긴 텍스트가 더 자연스럽게 줄바꿈되도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->