### PR TITLE
feat(analytics): Amplitude Session Replay 연동 (학생 PII conservative 마스킹)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.42.4",
+    "@amplitude/plugin-session-replay-browser": "^1.33.0",
     "@next/bundle-analyzer": "^15.3.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1",

--- a/src/lib/analytics/amplitude.ts
+++ b/src/lib/analytics/amplitude.ts
@@ -1,5 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser';
-import { ENV } from '@/config/environment';
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
+import { ENV, getEnvironment } from '@/config/environment';
 
 // SDK 직접 import 는 이 모듈에서만. 다른 코드는 setAnalyticsUser/resetAnalytics/initAnalytics 만 사용.
 // 향후 PostHog 등 다른 분석 도구로 교체할 때 한 곳만 수정하면 됨.
@@ -21,6 +22,22 @@ function ensureInit(): void {
     initialized = true; // 재시도 막기 위해 표시
     return;
   }
+  // Session Replay — DOM 녹화 플러그인. SDK 직접 의존은 이 모듈에만 둔다. init() 보다 *먼저* add 해야 한다.
+  // 마스킹: 학생 PII(이름·학번·학과·성적)는 화면에 평문(<div>/<td>)으로 렌더되는데, 기본값 medium 은
+  // <input> 만 마스킹하고 일반 텍스트는 평문 녹화한다 → conservative 로 전체 텍스트+폼을 마스킹.
+  // 안전한 UI chrome 만 노출하려면 추후 unmaskSelector(['[data-amp-unmask]']) 로 선택 해제.
+  // ⚠️ Amplitude 대시보드의 Session Replay Settings(원격 설정)가 이 privacyConfig 보다 우선하므로
+  //    대시보드 마스킹도 동일하게 conservative 로 맞춰야 코드 의도가 보장된다.
+  // sampleRate: 세션 단위 비율(0~1). 기본 0(아무것도 안 잡힘)이라 환경별로 명시한다. 운영은 낮게 시작해
+  //   점진 상향(재배포 없이 Remote Config 로도 조정 가능). prod 외(dev/preview)는 100% 로 디버깅 편의.
+  amplitude.add(
+    sessionReplayPlugin({
+      sampleRate: getEnvironment() === 'production' ? 0.1 : 1,
+      privacyConfig: {
+        defaultMaskLevel: 'conservative',
+      },
+    }),
+  );
   amplitude.init(ENV.AMPLITUDE_API_KEY, undefined, {
     // forms/fileDownloads/elementInteractions 는 의도적으로 OFF — 이벤트 양 과다 방지
     defaultTracking: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@amplitude/analytics-connector@npm:^1.6.4":
+"@amplitude/analytics-client-common@npm:2.4.52":
+  version: 2.4.52
+  resolution: "@amplitude/analytics-client-common@npm:2.4.52"
+  dependencies:
+    "@amplitude/analytics-connector": "npm:^1.4.8"
+    "@amplitude/analytics-core": "npm:2.52.0"
+    "@amplitude/analytics-types": "npm:2.11.1"
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/526b0b22f47c6e13e57f603c36a942448238cc6a0591ce65f080894a1a9a790815840df2bbb5ea06a2b594923ab19cbe349754a11906f663b2d834ac5a1179ac
+  languageName: node
+  linkType: hard
+
+"@amplitude/analytics-connector@npm:^1.4.8, @amplitude/analytics-connector@npm:^1.6.4":
   version: 1.6.4
   resolution: "@amplitude/analytics-connector@npm:1.6.4"
   checksum: 10c0/b084180029e48c011fffc47301462fc2db06830421348ca5fdf235fb6d30e4c0309161eb4392350bc00ab2bf7537306f18b9dfffa9998f70db2b6f31470f0e88
@@ -39,6 +51,35 @@ __metadata:
     tslib: "npm:^2.4.1"
     zen-observable: "npm:0.10.0"
   checksum: 10c0/2526824f268f02b3aff6cd7de761e6033716326514ad968f16cd4fc88d0d4831c753433e5a4c4637c0985d5ee1c9591afa305519a09ab08226aeb9e13aaa0019
+  languageName: node
+  linkType: hard
+
+"@amplitude/analytics-core@npm:2.52.0":
+  version: 2.52.0
+  resolution: "@amplitude/analytics-core@npm:2.52.0"
+  dependencies:
+    "@amplitude/analytics-connector": "npm:^1.6.4"
+    "@types/zen-observable": "npm:0.8.3"
+    safe-json-stringify: "npm:1.2.0"
+    tslib: "npm:^2.4.1"
+    zen-observable: "npm:0.10.0"
+  checksum: 10c0/1d82785b6331de26871b33947c4e2de09a131ee78c7cee07c0611cc386986f150d7cc72c9f3258a40da6549ec03566397bca35ea12d928b65c65e37752fd34b8
+  languageName: node
+  linkType: hard
+
+"@amplitude/analytics-types@npm:2.11.1":
+  version: 2.11.1
+  resolution: "@amplitude/analytics-types@npm:2.11.1"
+  checksum: 10c0/620fd98abcfa9569dd8897c0af0b7b15b83208fbb9c37a0c5905d0e358fe28552596efa2e80698150ae208ff00ed548ad1ba573452e68cf9522cc2870bbf2c19
+  languageName: node
+  linkType: hard
+
+"@amplitude/experiment-core@npm:0.7.2":
+  version: 0.7.2
+  resolution: "@amplitude/experiment-core@npm:0.7.2"
+  dependencies:
+    js-base64: "npm:^3.7.5"
+  checksum: 10c0/e5fd1c8232015d6ecf8a8ad7307ef4feb3c8305c115f2e4cb24bbcd0bb4716bbfaa9ac003d530c1911235da9b10226880fdfb58470fc15e5645d62b663ba1b02
   languageName: node
   linkType: hard
 
@@ -102,6 +143,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@amplitude/plugin-session-replay-browser@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "@amplitude/plugin-session-replay-browser@npm:1.33.0"
+  dependencies:
+    "@amplitude/analytics-client-common": "npm:2.4.52"
+    "@amplitude/analytics-core": "npm:2.52.0"
+    "@amplitude/analytics-types": "npm:2.11.1"
+    "@amplitude/rrweb-plugin-console-record": "npm:2.0.0-alpha.40"
+    "@amplitude/rrweb-record": "npm:2.0.0-alpha.40"
+    "@amplitude/session-replay-browser": "npm:1.47.0"
+    idb-keyval: "npm:^6.2.1"
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/9fe87b4d6186d29e236f3d107751326643ec754fd8630c2d14f0f259d50d035906c59114949ae38c7a6b470e1cf76c0f1b3517b0f9f28d878387252898644fff
+  languageName: node
+  linkType: hard
+
 "@amplitude/plugin-web-vitals-browser@npm:1.1.33":
   version: 1.1.33
   resolution: "@amplitude/plugin-web-vitals-browser@npm:1.1.33"
@@ -110,6 +167,132 @@ __metadata:
     tslib: "npm:^2.4.1"
     web-vitals: "npm:5.1.0"
   checksum: 10c0/96f224cf795054d98e303a6cb4548ded1e98cd0c3e32ddbe2e721cca5ab3edc6993e752d7693ae6bbe445ef7c737932282aba739fa51347da1a1af0635b6f653
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrdom@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@amplitude/rrdom@npm:2.1.0"
+  dependencies:
+    "@amplitude/rrweb-snapshot": "npm:^2.1.0"
+  checksum: 10c0/f80ffb98d9654e454a813147122e66d1fb2c049cdd157ee2fd877e2b2bee734f874f70f6a412834e07cc5017c88878580dd3820a4bea6412653ec42a9a604d00
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-packer@npm:2.0.0-alpha.40":
+  version: 2.0.0-alpha.40
+  resolution: "@amplitude/rrweb-packer@npm:2.0.0-alpha.40"
+  dependencies:
+    "@amplitude/rrweb-types": "npm:^2.0.0-alpha.40"
+    fflate: "npm:^0.4.4"
+  checksum: 10c0/9d06a3fa0f5520a9fe5ce37e31d78f241972f11edfeda1a364c7a627fa27e2392e6f916f9979495f341592a2b2dc19471ef42fb9290f0ccbd59554ae0b336135
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-plugin-console-record@npm:2.0.0-alpha.40":
+  version: 2.0.0-alpha.40
+  resolution: "@amplitude/rrweb-plugin-console-record@npm:2.0.0-alpha.40"
+  peerDependencies:
+    "@amplitude/rrweb": ^2.0.0-alpha.40
+  checksum: 10c0/c3dc361f794a07d2ea4634e700d7eb18d6c6fcc5c419c35084ab63feb17494bba371e7682fa3daa2b110a7a712a0799c08b2e751d1b9e76e199a23adf4755b8c
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-record@npm:2.0.0-alpha.40":
+  version: 2.0.0-alpha.40
+  resolution: "@amplitude/rrweb-record@npm:2.0.0-alpha.40"
+  dependencies:
+    "@amplitude/rrweb": "npm:^2.0.0-alpha.40"
+    "@amplitude/rrweb-types": "npm:^2.0.0-alpha.40"
+  checksum: 10c0/752ffb081bcb3c1f6ccd5592099af3c8239223ff2616e16ab7a5f31aed963ba18b64f50f96e515a6ca7b26149d1bf5c032a2f04c2e65fac899a0e0e3d13a7f08
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-snapshot@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@amplitude/rrweb-snapshot@npm:2.1.0"
+  dependencies:
+    postcss: "npm:^8.4.38"
+  checksum: 10c0/5462afce83d7812121d15cf3ad1f7c1cb39b63b60fca8520a8b0c99e2bec4b6e3869f8bac6b93f68b360d4865a715da17647caec11ad90378caad6c8a2e40c12
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-types@npm:2.0.0-alpha.40":
+  version: 2.0.0-alpha.40
+  resolution: "@amplitude/rrweb-types@npm:2.0.0-alpha.40"
+  checksum: 10c0/cf231ce6560e8811ef0cea22d02e16d0ba661fe48b3f6b19f83d86f2e08fca84e1d7082f7b37dc667d713003f3e03a2d335e2edb61dab95654b202f962ccc9be
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-types@npm:^2.0.0-alpha.40, @amplitude/rrweb-types@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@amplitude/rrweb-types@npm:2.1.0"
+  checksum: 10c0/3b0b387a7856fcce198ca3525f51e82020001140acb89b576151062c30e20e9ce397216647c90966130c57ece104ad00a198f7fda9e9873dfcc1b207f3a3c805
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-utils@npm:2.0.0-alpha.40":
+  version: 2.0.0-alpha.40
+  resolution: "@amplitude/rrweb-utils@npm:2.0.0-alpha.40"
+  checksum: 10c0/029ac384066817b89a026872008832fb325fb45e46c9983bf12fad3a9a2ca4a00d040fef1dae1a7c85302596135e999f166b3eb05e1a3578a67fac06fa3c8f61
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb-utils@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@amplitude/rrweb-utils@npm:2.1.0"
+  checksum: 10c0/925be95651c9bec09758c0a7f4b13ede363db5826b38e111ba9ad4a7cff8fbec6f45a452c2082e7f7b8198428fd6efdbe8fa1ae187608b2a8b8272f2b17417a5
+  languageName: node
+  linkType: hard
+
+"@amplitude/rrweb@npm:^2.0.0-alpha.40":
+  version: 2.1.1
+  resolution: "@amplitude/rrweb@npm:2.1.1"
+  dependencies:
+    "@amplitude/rrdom": "npm:^2.1.0"
+    "@amplitude/rrweb-snapshot": "npm:^2.1.0"
+    "@amplitude/rrweb-types": "npm:^2.1.0"
+    "@amplitude/rrweb-utils": "npm:^2.1.0"
+    "@types/css-font-loading-module": "npm:0.0.7"
+    "@xstate/fsm": "npm:^1.4.0"
+    base64-arraybuffer: "npm:^1.0.1"
+    mitt: "npm:^3.0.0"
+  checksum: 10c0/1bbcf0df9e90a7cf656c4bcd4a8ba20faeef603bbca6ce3eb4cdd2e04d442ecf1bccd3a2f3cb7aa61cc591c039fb0fdcbcb828af85af2c47c2447ef701ec5a38
+  languageName: node
+  linkType: hard
+
+"@amplitude/session-replay-browser@npm:1.47.0":
+  version: 1.47.0
+  resolution: "@amplitude/session-replay-browser@npm:1.47.0"
+  dependencies:
+    "@amplitude/analytics-client-common": "npm:2.4.52"
+    "@amplitude/analytics-core": "npm:2.52.0"
+    "@amplitude/analytics-types": "npm:2.11.1"
+    "@amplitude/experiment-core": "npm:0.7.2"
+    "@amplitude/rrweb-packer": "npm:2.0.0-alpha.40"
+    "@amplitude/rrweb-plugin-console-record": "npm:2.0.0-alpha.40"
+    "@amplitude/rrweb-record": "npm:2.0.0-alpha.40"
+    "@amplitude/rrweb-types": "npm:2.0.0-alpha.40"
+    "@amplitude/rrweb-utils": "npm:2.0.0-alpha.40"
+    "@amplitude/targeting": "npm:0.3.2"
+    "@rollup/plugin-replace": "npm:^6.0.1"
+    idb: "npm:8.0.0"
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/450f7fb40270595bafc833877e8e972294ce5286aa1ebc2c7fba5d4f929a686bd1e5fb44537e10c29435143133f4991029820a737f4bc48eee7bee5189e9377b
+  languageName: node
+  linkType: hard
+
+"@amplitude/targeting@npm:0.3.2":
+  version: 0.3.2
+  resolution: "@amplitude/targeting@npm:0.3.2"
+  dependencies:
+    "@amplitude/analytics-client-common": "npm:2.4.52"
+    "@amplitude/analytics-core": "npm:2.52.0"
+    "@amplitude/analytics-types": "npm:2.11.1"
+    "@amplitude/experiment-core": "npm:0.7.2"
+    idb: "npm:8.0.0"
+    tslib: "npm:^2.4.1"
+  checksum: 10c0/6b8ac440ef0ab96784981ab75a00d2541baea09312fcc1f2bf6ca9d166038603c4b70984c3781d9e7721c9b8caecf5386e589f8257eca51bf0607061ea2cf242
   languageName: node
   linkType: hard
 
@@ -5231,6 +5414,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-replace@npm:^6.0.1":
+  version: 6.0.3
+  resolution: "@rollup/plugin-replace@npm:6.0.3"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.0.1"
+    magic-string: "npm:^0.30.3"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10c0/93217c52fe86b03363bc534b5f07963ac4fd6b91f19f6070a66809b0c65a036b3b234624a65a8bfcc01a8dc0e42838feae03c021b0d1e5e91753c503c4d70cd6
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^5.0.1":
   version: 5.1.4
   resolution: "@rollup/pluginutils@npm:5.1.4"
@@ -6690,6 +6888,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/css-font-loading-module@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@types/css-font-loading-module@npm:0.0.7"
+  checksum: 10c0/a74759a14bcc7d60a1a1d863b53b7638d4aa7f88f1d97347426262cc6fe8f9335d8fa80c7e0608cd67e33ff0067608e9b5475a1227a684e1dfad3cac87df1405
+  languageName: node
+  linkType: hard
+
 "@types/estree@npm:*, @types/estree@npm:1.0.7, @types/estree@npm:^1.0.0":
   version: 1.0.7
   resolution: "@types/estree@npm:1.0.7"
@@ -7205,6 +7410,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xstate/fsm@npm:^1.4.0":
+  version: 1.6.5
+  resolution: "@xstate/fsm@npm:1.6.5"
+  checksum: 10c0/472fe625b84b9e7102b8774e80c441b8b7dbc9585e700223d9c7a39c583d38ba50636909a5d749d44b361555daa841862f932a29c52b81c8829a74884e715bf4
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^3.0.0":
   version: 3.0.1
   resolution: "abbrev@npm:3.0.1"
@@ -7635,6 +7847,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-arraybuffer@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 10c0/3acac95c70f9406e87a41073558ba85b6be9dbffb013a3d2a710e3f2d534d506c911847d5d9be4de458af6362c676de0a5c4c2d7bdf4def502d00b313368e72f
+  languageName: node
+  linkType: hard
+
 "bin-links@npm:^5.0.0":
   version: 5.0.0
   resolution: "bin-links@npm:5.0.0"
@@ -7966,6 +8185,7 @@ __metadata:
   resolution: "chukchuk-haksa@workspace:."
   dependencies:
     "@amplitude/analytics-browser": "npm:^2.42.4"
+    "@amplitude/plugin-session-replay-browser": "npm:^1.33.0"
     "@next/bundle-analyzer": "npm:^15.3.0"
     "@opennextjs/cloudflare": "npm:^1"
     "@opentelemetry/api": "npm:^1.9.0"
@@ -9663,6 +9883,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fflate@npm:^0.4.4":
+  version: 0.4.8
+  resolution: "fflate@npm:0.4.8"
+  checksum: 10c0/29d1eddaaa5deab61b1c6b0d21282adacadbc4d2c01e94d8b1ee784398151673b9c563e53f97a801bc410a1ae55e8de5378114a743430e643e7a0644ba8e5a42
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^6.0.1":
   version: 6.0.1
   resolution: "file-entry-cache@npm:6.0.1"
@@ -10349,10 +10576,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"idb-keyval@npm:^6.2.1":
+  version: 6.2.6
+  resolution: "idb-keyval@npm:6.2.6"
+  checksum: 10c0/2718162d5f80abd58d4a2cd17ead760cf5fb959b98a23a21800063f45887cd5421e9ff4d44b484d1911a2573b79e2ebeeca322eb07ea145fa8c960d8cf35642f
+  languageName: node
+  linkType: hard
+
 "idb@npm:7.1.1":
   version: 7.1.1
   resolution: "idb@npm:7.1.1"
   checksum: 10c0/72418e4397638797ee2089f97b45fc29f937b830bc0eb4126f4a9889ecf10320ceacf3a177fe5d7ffaf6b4fe38b20bbd210151549bfdc881db8081eed41c870d
+  languageName: node
+  linkType: hard
+
+"idb@npm:8.0.0":
+  version: 8.0.0
+  resolution: "idb@npm:8.0.0"
+  checksum: 10c0/d27547e03939d3d269cea38c3d4528569621ec134c717ebfc1ff816dce18e4f77372dba1d930384a9949ac56dc600e3790f98f1812a4164004e71fec302ee491
   languageName: node
   linkType: hard
 
@@ -10856,6 +11097,13 @@ __metadata:
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10c0/4ceac133a08c8faff7eac84aabb917e85e8257f5ad659e843004ce76e981c457c390a220881748ac67ba1b940b9b729b30fb85cbaf6e7989f04b6002c94da331
+  languageName: node
+  linkType: hard
+
+"js-base64@npm:^3.7.5":
+  version: 3.8.0
+  resolution: "js-base64@npm:3.8.0"
+  checksum: 10c0/f04b51fef12e49e2b14cf904b3947583fb6ec77815b0597b5b282151c62e22acc61c9a016f53eb76b413a682b68cc232b7afaba7d67e6fd6e450415103038194
   languageName: node
   linkType: hard
 
@@ -11461,6 +11709,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mitt@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: 10c0/3ab4fdecf3be8c5255536faa07064d05caa3dd332bd318ff02e04621f7b3069ca1de9106cfe8e7ced675abfc2bec2ce4c4ef321c4a1bb1fb29df8ae090741913
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:1.0.4":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -11506,6 +11761,15 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.12":
+  version: 3.3.15
+  resolution: "nanoid@npm:3.3.15"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/e0b12e3a1d361f74150fa4b25631d0ae29f7162dab01a12f0f1be1f53b7a2a219f9b729504e474d4821207d0fe349bd3c97569ab5cf7ec2fff6aa94711956c93
   languageName: node
   linkType: hard
 
@@ -12365,6 +12629,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/b75510d7b28c3ab728c8733dd01538314a18c52af426f199a3c9177e63eb08602a3938bfb66b62dc01350b9aed62087eabbf229af97a1659eb8d3513cec823b3
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.38":
+  version: 8.5.16
+  resolution: "postcss@npm:8.5.16"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/625de7a02f662f3a340964d14b487bd5097adf16f5f171e257d19005ba37aea8768ee446557500e88e91ca46b4d14d6cb4a0bf033c6ec0c8c0b660d85719f1ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 배경

사용자가 서비스에서 실제로 어떤 화면을 보고 어디서 막히는지 "녹화 영상처럼" 다시 보고 싶을 때가 있습니다. 클릭 이벤트 숫자만으로는 "왜 이탈했는지"를 알기 어렵습니다.

우리는 이미 Amplitude로 이벤트를 수집하고 있는데, Amplitude에는 **Session Replay**라는 기능이 있습니다. 사용자의 화면(DOM)을 영상처럼 재생해 주는 기능입니다. 이걸 켜면 특정 이벤트를 누른 사용자의 실제 화면 흐름을 그대로 돌려볼 수 있습니다.

다만 우리 서비스는 **이름·학번·학과·성적 같은 개인정보(PII)가 화면에 그대로 표시**됩니다. 화면을 녹화한다는 건 이 정보까지 녹화될 수 있다는 뜻이라, "어떻게 켜느냐"보다 "어떻게 안전하게 가리느냐"가 더 중요한 작업이었습니다.

## 해결 과정

- **기존 구조 확인**: Amplitude SDK 직접 호출은 모두 `src/lib/analytics/amplitude.ts` 한 파일(`ensureInit()`)에만 모여 있습니다. 그래서 이 한 곳만 고치면 됩니다.
- **연동 방식 선택**: 우리는 이미 `@amplitude/analytics-browser` v2를 쓰므로, 공식 권장대로 **플러그인(`@amplitude/plugin-session-replay-browser`)** 을 붙이는 방식을 택했습니다. (신규 프로젝트라면 통합 SDK를 권장하지만, 우리는 교체 비용이 큰 통합 SDK 대신 변경이 가장 적은 플러그인이 맞습니다.)
- **호출 순서**: 공식 문서 기준 `sessionReplayPlugin`은 **`amplitude.init()`보다 먼저** `amplitude.add()` 로 등록해야 합니다. 기존 init 코드 바로 위에 추가했습니다.
- **마스킹(가장 중요)**: Session Replay의 기본 마스킹 레벨 `medium`은 **입력창(`<input>`)만 가리고**, `<div>`/`<td>`에 그려진 일반 텍스트(=우리 PII)는 그대로 녹화합니다. 그래서 모든 텍스트와 폼을 가리는 **`conservative`** 레벨로 설정했습니다.
- **샘플링**: `sampleRate`는 기본값이 0이라 아무것도 안 잡힙니다. 운영(`production`)은 보수적으로 **10%(0.1)**, 그 외(dev/preview)는 100%로 두어 디버깅을 쉽게 했습니다. 이 비율은 재배포 없이 Amplitude Remote Config로도 조정할 수 있습니다.
- **키/시크릿**: Session Replay는 **기존 Amplitude API 키를 그대로 재사용**합니다. 새 키나 CI 시크릿 추가가 필요 없어 인프라 변경이 0입니다.

## 결과

- 운영에서 일부 세션(10%)의 화면 흐름을 영상처럼 재생할 수 있게 됩니다.
- 학생 개인정보는 `conservative` 마스킹으로 기본 가려집니다.
- 핵심 변경: 플러그인 1개 추가 + `amplitude.ts`에 약 12줄 추가. 다른 파일·CI·환경변수 변경 없음.

## 어떻게 사용하나요?

코드 쪽은 자동입니다. 앱이 켜질 때 `AnalyticsProvider`가 기존처럼 `initAnalytics()`를 호출하면 플러그인이 함께 등록됩니다.

```ts
// src/lib/analytics/amplitude.ts (ensureInit 내부)
amplitude.add(
  sessionReplayPlugin({
    sampleRate: getEnvironment() === 'production' ? 0.1 : 1,
    privacyConfig: { defaultMaskLevel: 'conservative' },
  }),
);
amplitude.init(ENV.AMPLITUDE_API_KEY, ...); // 기존 그대로
```

확인 방법: 배포 후 브라우저에서 이벤트에 `[Amplitude] Session Replay ID`(`<deviceId>/<sessionId>`) 속성이 붙고, 캡처 성공 시 `[Amplitude] Replay Captured` 이벤트가 보이면 정상입니다.

## 확인한 내용

- [x] `yarn type-check` — 에러 0
- [x] `yarn lint` — 에러 0 (경고 18건은 이번 변경과 무관한 기존 파일들: `client.ts`, `useInternalRouter.ts` 등. 수정한 `amplitude.ts`는 무경고)
- [x] 플러그인 타입 시그니처 확인 — `defaultMaskLevel`은 `'light' | 'medium' | 'conservative'` 유니온, `'conservative'` 유효
- [ ] 프로덕션 빌드는 미실행 (변경이 기존 'use client' init 경로 안쪽이라 type-check/lint로 충분하다고 판단)

## 리뷰할 때 봐주세요 (⚠️ 코드 외 필수 후속 작업)

이 PR 머지만으로는 **동작하지 않거나 PII가 노출될 수 있습니다.** 아래 대시보드 설정이 함께 필요합니다.

- **Amplitude 대시보드에서 해당 프로젝트의 Session Replay를 Enable** — 안 켜면 캡처 자체가 안 됩니다.
- **대시보드 _Session Replay Settings_ 의 마스킹도 `Conservative`로 설정** — Amplitude는 **원격 설정이 코드의 `privacyConfig`를 override**합니다. 대시보드가 느슨하면 코드가 conservative여도 학생 PII가 평문으로 녹화됩니다.
- 운영 `sampleRate` 10%가 적절한지(비용/쿼터는 조직 단위 월간) 검토 부탁드립니다.

## 아직 하지 않은 것

- HTML 속성(`title`/`alt`/`placeholder`/`data-*`)은 마스킹 대상이 아닙니다. 현재 PII를 속성에 담는 코드는 확인되지 않았으나, 추후 그런 코드가 생기면 별도 마스킹 필요.
- 성적표 등 특정 영역만 통째로 제외하려면 `blockSelector`/`.amp-block` 추가가 필요(이번 범위 밖).
- canvas/WebGL/Lottie, cross-origin iframe(GAM 광고 등)은 Session Replay가 캡처하지 못합니다(제품 한계).
